### PR TITLE
A very simple solution to debug layout locally

### DIFF
--- a/app/Jasonette.xcodeproj/project.pbxproj
+++ b/app/Jasonette.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		30CC30341DD59879007C11D6 /* main.json in Resources */ = {isa = PBXBuildFile; fileRef = 30CC30331DD59879007C11D6 /* main.json */; };
 		5E09562D1DA33515007ADC78 /* JasonLabelComponent.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E09562C1DA33514007ADC78 /* JasonLabelComponent.m */; };
 		5E0956301DA34D70007ADC78 /* JasonImageComponent.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E09562F1DA34D6F007ADC78 /* JasonImageComponent.m */; };
 		5E0956331DA34EEA007ADC78 /* JasonButtonComponent.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E0956321DA34EEA007ADC78 /* JasonButtonComponent.m */; };
@@ -76,6 +77,7 @@
 /* Begin PBXFileReference section */
 		1BD8E8486EE7AF4E4934685E /* Pods-Jasonette.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Jasonette.release.xcconfig"; path = "Pods/Target Support Files/Pods-Jasonette/Pods-Jasonette.release.xcconfig"; sourceTree = "<group>"; };
 		2F0FCC971E030AF932E421D4 /* Pods_Jasonette.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Jasonette.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		30CC30331DD59879007C11D6 /* main.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = main.json; sourceTree = "<group>"; };
 		5E09562A1DA33264007ADC78 /* JasonComponentProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JasonComponentProtocol.h; sourceTree = "<group>"; };
 		5E09562B1DA33514007ADC78 /* JasonLabelComponent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JasonLabelComponent.h; sourceTree = "<group>"; };
 		5E09562C1DA33514007ADC78 /* JasonLabelComponent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JasonLabelComponent.m; sourceTree = "<group>"; };
@@ -248,6 +250,7 @@
 				5E3176601D1E400C00D87778 /* JasonAppDelegate.m */,
 				5E3176C01D1E411E00D87778 /* LaunchScreen.storyboard */,
 				5E31765D1D1E400C00D87778 /* main.m */,
+				30CC30331DD59879007C11D6 /* main.json */,
 			);
 			name = Launcher;
 			sourceTree = "<group>";
@@ -713,6 +716,7 @@
 				5E3177531D1E411F00D87778 /* Next@2x.png in Resources */,
 				5E31773A1D1E411F00D87778 /* icon-success@2x.png in Resources */,
 				5E3177671D1E411F00D87778 /* rss.js in Resources */,
+				30CC30341DD59879007C11D6 /* main.json in Resources */,
 				5E3177481D1E411F00D87778 /* LaunchScreen.storyboard in Resources */,
 				5E3177361D1E411F00D87778 /* icon-error@2x.png in Resources */,
 				5E31775F1D1E411F00D87778 /* placeholder@2x.png in Resources */,

--- a/app/Jasonette/Jason.m
+++ b/app/Jasonette/Jason.m
@@ -51,7 +51,14 @@
     JasonAppDelegate *app = (JasonAppDelegate *)[[UIApplication sharedApplication] delegate];
     NSURL *file = [[NSBundle mainBundle] URLForResource:@"settings" withExtension:@"plist"];
     NSDictionary *plist = [NSDictionary dictionaryWithContentsOfURL:file];
+#if DEBUG
+    if ([plist[@"use_main"] boolValue]) {
+        ROOT_URL = [[[NSBundle mainBundle] URLForResource:@"main" withExtension:@"json"] absoluteString];
+    }
+    if (!ROOT_URL.length) ROOT_URL = plist[@"url"];
+#else
     ROOT_URL = plist[@"url"];
+#endif
     
     
     JasonViewController *vc = [[JasonViewController alloc] init];

--- a/app/Jasonette/main.json
+++ b/app/Jasonette/main.json
@@ -1,0 +1,125 @@
+{
+  "$jason": {
+    "head": {
+      "title": "{ ˃̵̑ᴥ˂̵̑}",
+      "actions": {
+        "$foreground": {
+          "type": "$reload"
+        },
+        "$pull": {
+          "type": "$reload"
+        }
+      }
+    },
+    "body": {
+      "header": {
+        "style": {
+          "background": "#ffffff"
+        }
+      },
+      "style": {
+        "background": "#ffffff",
+        "border": "none"
+      },
+      "sections": [
+        {
+          "items": [
+            {
+              "type": "vertical",
+              "style": {
+                "padding": "30",
+                "spacing": "20",
+                "align": "center"
+              },
+              "components": [
+                {
+                  "type": "label",
+                  "text": "It's ALIVE!",
+                  "style": {
+                    "align": "center",
+                    "font": "Courier-Bold",
+                    "size": "18"
+                  }
+                },
+                {
+                  "type": "image",
+                  "url" : "https://pbs.twimg.com/profile_images/557061751150112768/eMwi4Xz2.jpeg",
+                  "style" : {
+                      "width" : "200",
+                      "corner_radius" : "100",
+                      "border_width" : "3",
+                      "border_color" : "#FF0000"
+                  }
+                },
+                {
+                  "type": "label",
+                  "text": "This is a demo app. You can make your own app by changing the url inside settings.plist",
+                  "style": {
+                    "align": "center",
+                    "font": "Courier",
+                    "padding": "30",
+                    "size": "14"
+                  }
+                },
+                {
+                  "type": "label",
+                  "text": "{ ˃̵̑ᴥ˂̵̑}",
+                  "style": {
+                    "align": "center",
+                    "font": "HelveticaNeue-Bold",
+                    "size": "50"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "label",
+              "style": {
+                "align": "right",
+                "padding": "10",
+                "color": "#000000",
+                "font": "HelveticaNeue",
+                "size": "12"
+              },
+              "text": "Check out Live DEMO",
+              "href": {
+                "url": "https://jasonette.github.io/Jasonpedia/demo.json",
+                "fresh": "true"
+              }
+            },
+            {
+              "type": "label",
+              "style": {
+                "align": "right",
+                "padding": "10",
+                "color": "#000000",
+                "font": "HelveticaNeue",
+                "size": "12"
+              },
+              "text": "Watch the tutorial video",
+              "href": {
+                "url": "https://www.youtube.com/watch?v=hfevBAAfCMQ",
+                "view": "Web"
+              }
+            },
+            {
+              "type": "label",
+              "style": {
+                "align": "right",
+                "padding": "10",
+                "color": "#000000",
+                "font": "HelveticaNeue",
+                "size": "12"
+              },
+              "text": "View documentation",
+              "href": {
+                "url": "https://jasonette.github.io/documentation",
+                "view": "Web"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/app/Jasonette/settings.plist
+++ b/app/Jasonette/settings.plist
@@ -8,5 +8,7 @@
 	<string></string>
 	<key>url</key>
 	<string>https://jasonette.github.io/Jasonpedia/hello.json</string>
+	<key>use_main</key>
+	<false/>
 </dict>
 </plist>

--- a/app/main.json
+++ b/app/main.json
@@ -1,0 +1,127 @@
+{
+  "$jason": {
+    "head": {
+      "title": "{ ˃̵̑ᴥ˂̵̑}",
+      "actions": {
+        "$foreground": {
+          "type": "$reload"
+        },
+        "$pull": {
+          "type": "$reload"
+        }
+      }
+    },
+    "body": {
+      "header": {
+        "style": {
+          "background": "#ffffff"
+        }
+      },
+      "style": {
+        "background": "#ffffff",
+        "border": "none"
+      },
+      "sections": [
+        {
+          "items": [
+            {
+              "type": "vertical",
+              "style": {
+                "padding": "30",
+                "spacing": "20",
+                "align": "center"
+              },
+              "components": [
+                {
+                  "type": "label",
+                  "text": "It's ALIVE!",
+                  "style": {
+                    "align": "center",
+                    "font": "Courier-Bold",
+                    "size": "18"
+                  }
+                },
+                {
+                  "type": "image",
+                  "url" : "https://pbs.twimg.com/profile_images/557061751150112768/eMwi4Xz2.jpeg",
+                  "style" : {
+                      "width" : "200",
+                      "corner_radius" : "100",
+                      "border_width" : "3",
+                      "border_color" : "#FF0000"
+                  }
+                },
+                {
+                  "type": "label",
+                  "text": "This is a demo app. You can make your own app by changing the url inside settings.plist",
+                  "style": {
+                    "align": "center",
+                    "font": "Courier",
+                    "padding": "30",
+                    "size": "14"
+                  }
+                },
+                {
+                  "type": "label",
+                  "text": "{ ˃̵̑ᴥ˂̵̑}",
+                  "style": {
+                    "align": "center",
+                    "font": "HelveticaNeue-Bold",
+                    "size": "50"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "label",
+              "style": {
+                "align": "right",
+                "padding": "10",
+                "color": "#000000",
+                "font": "HelveticaNeue",
+                "size": "12"
+              },
+              "text": "Check out Live DEMO",
+              "href": {
+                "url": "https://jasonette.github.io/Jasonpedia/demo.json",
+                "fresh": "true"
+              }
+            },
+            {
+              "type": "label",
+              "style": {
+                "align": "right",
+                "padding": "10",
+                "color": "#000000",
+                "font": "HelveticaNeue",
+                "size": "12",
+                "border_width": "2.0",
+                "border_color": "#bebebe"
+              },
+              "text": "Watch the tutorial video",
+              "href": {
+                "url": "https://www.youtube.com/watch?v=hfevBAAfCMQ",
+                "view": "Web"
+              }
+            },
+            {
+              "type": "label",
+              "style": {
+                "align": "right",
+                "padding": "10",
+                "color": "#000000",
+                "font": "HelveticaNeue",
+                "size": "12"
+              },
+              "text": "View documentation",
+              "href": {
+                "url": "https://jasonette.github.io/documentation",
+                "view": "Web"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This request is a very simple solution to let users debug layout locally before submitting the final JSON to the server.

## How to enable this feature
1、In `setting.plist`, put `use_main` to `YES`.
2、Add your JSON file named `main.json` into the application.
![image](https://cloud.githubusercontent.com/assets/5186464/20243069/458a3e24-a982-11e6-954d-708890cc2841.png)

> To avoid a sudden modification of the demo application, I turned off the `use_main`. To test it out, you need to turn it back on.

## How it worked
The only code-changes is just a replacement of the `ROOT_URL` with the `local file URL of main.json` in `DEBUG` mode. In a scheme without `DEBUG`, or while the `main.json` cannot be found, this feature will simply be ignored.


