### PR TITLE
Supporting daemon type actions

### DIFF
--- a/app/Jasonette/Jason.m
+++ b/app/Jasonette/Jason.m
@@ -52,6 +52,12 @@
                    name:@"Jason.error"
                  object:nil];
 
+        [[NSNotificationCenter defaultCenter]
+            addObserver:self
+               selector:@selector(notifyCall:)
+                   name:@"Jason.call"
+                 object:nil];
+
     }
     return self;
 }
@@ -67,6 +73,12 @@
     NSDictionary *args = notification.object;
     NSLog(@"JasonCore: notifyError: %@", args);
     [[Jason client] error:args];
+}
+
+- (void)notifyCall:(NSNotification *)notification {
+    NSDictionary *args = notification.object;
+    NSLog(@"JasonCore: notifyCall: %@", args);
+    [[Jason client] call:args];
 }
 
 
@@ -621,6 +633,8 @@
     tabController = navigationController.tabBarController;
         
     VC.url = [VC.url stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
+    
+    VC.modules = [[NSMutableDictionary alloc] init];
     
     // Set the stylesheet
     if(VC.style){
@@ -2335,7 +2349,12 @@
                             NSLog(@"Plugin: class: %@", PluginClass);
 
                             // Initialize Plugin
-                            module = [[PluginClass alloc] init];  // could go away if we had some sort of plug in registration
+                            if(VC.modules && VC.modules[type]){
+                                module = modules[type];
+                            } else {
+                                module = [[PluginClass alloc] init];  // could go away if we had some sort of plug in registration
+                                VC.modules[type] = module;
+                            }
 
                             [[NSNotificationCenter defaultCenter]
                                     postNotificationName:plugin_path
@@ -2386,7 +2405,13 @@
                             NSString *methodName = tokens[1];
                             SEL method = NSSelectorFromString(methodName);
                             
-                            module = [[ActionClass alloc] init];
+                            if(VC.modules && VC.modules[type]){
+                                module = modules[type];
+                            } else {
+                                module = [[ActionClass alloc] init];  // could go away if we had some sort of plug in registration
+                                VC.modules[type] = module;
+                            }
+
                             if([module respondsToSelector:@selector(VC)]) [module setValue:VC forKey:@"VC"];
                             if([module respondsToSelector:@selector(options)]) [module setValue:[self options] forKey:@"options"];
                             [module performSelector:method];

--- a/app/Jasonette/JasonViewController.h
+++ b/app/Jasonette/JasonViewController.h
@@ -40,6 +40,7 @@
 
 @property (strong, nonatomic) NSDictionary *parser;
 @property (nonatomic, strong) NSDictionary *data;
+@property (strong, nonatomic) NSMutableDictionary *modules;
 
 @property (nonatomic, strong) NSMutableArray *sections;
 @property (nonatomic, strong) NSArray *rows;

--- a/app/Jasonette/JasonViewController.m
+++ b/app/Jasonette/JasonViewController.m
@@ -86,6 +86,7 @@
     self.callback = [[NSDictionary alloc] init];
     self.sections = [[NSMutableArray alloc] init];
     self.rows = [[NSArray alloc] init];
+    self.modules = [[NSMutableDictionary alloc] init];
     
     self.form = [[NSMutableDictionary alloc] init];
     self.tableView.delaysContentTouches = false;

--- a/app/Jasonette/RussianDollView.h
+++ b/app/Jasonette/RussianDollView.h
@@ -11,6 +11,7 @@
 @property (nonatomic, strong) NSString *url;
 @property (nonatomic, strong) NSDictionary *data;
 @property (nonatomic, strong) NSDictionary *options;
+@property (nonatomic, strong) NSMutableDictionary *modules;
 @property (nonatomic, strong) NSDictionary *parser;
 @property (nonatomic, strong) NSDictionary *callback;
 @property (nonatomic, strong) NSDictionary *nav;


### PR DESCRIPTION
Until now, actions have been something that’s just a one off thing that
does its job and goes away.

Now we are trying to support a new type of action that can stick around
as a daemon and sends events to Jason core so it can kick off a new
action call chain whenever the event occurs. (Like $load, $show,
$foreground, but for action).

To support this we need a new NSNotification endpoint for Jason core:
`call`, which kicks off any action call chain such as:

1. call inline

    {
      “type”: “$render”
    }

2. call by name

    {
      “trigger”: “refresh_view”
    }

Also we need to tie these Action instances to the parent view
controller so they don’t get garbage collected after execution—that’s
how they stick around to send notifications later. (Actually it’s not
even garbage collection, the previous approach actually reuses the same
`module` variable for every action call, so it’s impossible to refer to
them later)