### PR TITLE
Removing "access" in JSON auth when OAuth callback directly returns an access token

### DIFF
--- a/app/Jasonette/JasonOauthAction.m
+++ b/app/Jasonette/JasonOauthAction.m
@@ -956,76 +956,75 @@
         
         [self.VC.navigationController dismissViewControllerAnimated:YES completion:nil];
         
-        NSString *client_id = self.options[@"access"][@"client_id"];
-        NSString *client_secret = self.options[@"access"][@"client_secret"];
+        NSURL *url = notification.userInfo[@"url"];
+        // extract parameters
+        NSArray *returnValues = [self extractQueryParams:url.absoluteString];
         
-        NSDictionary *access_options = self.options[@"access"];
-        if(!access_options || access_options.count == 0){
-            [[Jason client] error];
+        // Exception case (Dropbox) where authorize returns access_token directly, in which case we don't need to go forward with the next step of requesting access_token again
+        NSString *access_token = [self valueForKey:@"access_token" fromQueryItems:returnValues];
+
+        if(access_token){
+            NSString *client_id = self.options[@"authorize"][@"client_id"];
+            
+            NSString *token_type = [self valueForKey:@"token_type" fromQueryItems:returnValues];
+            AFOAuthCredential *credential = [AFOAuthCredential credentialWithOAuthToken:access_token tokenType:token_type];
+            [AFOAuthCredential storeCredential:credential withIdentifier:client_id];
+            [[Jason client] success];
         } else {
-            if(!access_options[@"scheme"] || [access_options[@"scheme"] length] == 0
+            NSDictionary *access_options = self.options[@"access"];
+            
+            // Setup access params
+            NSMutableDictionary *access_data;
+            
+            if(access_options[@"data"]){
+                access_data = [access_options[@"data"] mutableCopy];
+            }
+            
+            NSString *client_id = self.options[@"access"][@"client_id"];
+            NSString *client_secret = self.options[@"access"][@"client_secret"];
+            
+            NSString *code = [self valueForKey:@"code" fromQueryItems:returnValues];
+            
+            if(!access_options || access_options.count == 0
+               || !access_options[@"scheme"] || [access_options[@"scheme"] length] == 0
                || !access_options[@"host"] || [access_options[@"host"] length] == 0
                || !access_options[@"path"] || [access_options[@"path"] length] == 0){
                 [[Jason client] error];
             } else {
-                // Setup access params
-                NSMutableDictionary *access_data;
-                
-                if(access_options[@"data"]){
-                    access_data = [access_options[@"data"] mutableCopy];
-                }
-                
-                NSURL *url = notification.userInfo[@"url"];
-                // extract parameters
-                NSArray *returnValues = [self extractQueryParams:url.absoluteString];
-                NSString *code = [self valueForKey:@"code" fromQueryItems:returnValues];
-                
-                // Exception case (Dropbox) where authorize returns access_token directly, in which case we don't need to go forward with the next step of requesting access_token again
-                NSString *access_token = [self valueForKey:@"access_token" fromQueryItems:returnValues];
-                if(access_token){
-                    NSString *token_type = [self valueForKey:@"token_type" fromQueryItems:returnValues];
-                    AFOAuthCredential *credential = [AFOAuthCredential credentialWithOAuthToken:access_token tokenType:token_type];
-                    [AFOAuthCredential storeCredential:credential withIdentifier:client_id];
-                    [[Jason client] success];
+                NSString *urlString = [NSString stringWithFormat:@"%@://%@", access_options[@"scheme"], access_options[@"host"]];
+                NSURL *baseURL = [NSURL URLWithString:urlString];
                     
-                } else {
-                    NSString *urlString = [NSString stringWithFormat:@"%@://%@", access_options[@"scheme"], access_options[@"host"]];
-                    NSURL *baseURL = [NSURL URLWithString:urlString];
-                    
-                    
-                    AFOAuth2Manager *OAuth2Manager = [[AFOAuth2Manager alloc] initWithBaseURL:baseURL
+                
+                AFOAuth2Manager *OAuth2Manager = [[AFOAuth2Manager alloc] initWithBaseURL:baseURL
                                                     clientID:client_id
                                                    secret:client_secret];
                     
-                    // In most cases oauth endpoints don't use basic auth (although it's more secure to use basic auth)
-                    // So the default is 'non basic auth'
+                // In most cases oauth endpoints don't use basic auth (although it's more secure to use basic auth)
+                // So the default is 'non basic auth'
                     
-                    if(access_options[@"basic"]){
-                        [OAuth2Manager setUseHTTPBasicAuthentication:YES];
-                    } else {
-                        [OAuth2Manager setUseHTTPBasicAuthentication:NO];
-                    }
-                    access_data[@"code"] = code;
-                    
-                    [OAuth2Manager authenticateUsingOAuthWithURLString:access_options[@"path"]
-                                                            parameters:access_data success:^(AFOAuthCredential *credential) {
+                if(access_options[@"basic"]){
+                    [OAuth2Manager setUseHTTPBasicAuthentication:YES];
+                } else {
+                    [OAuth2Manager setUseHTTPBasicAuthentication:NO];
+                }
+                access_data[@"code"] = code;
+                
+                [OAuth2Manager authenticateUsingOAuthWithURLString:access_options[@"path"]
+                                                        parameters:access_data success:^(AFOAuthCredential *credential) {
                                                                 [AFOAuthCredential storeCredential:credential
                                                                                     withIdentifier:client_id];
-                                                                [[Jason client] success];
+                                                            [[Jason client] success];
 
-                                                            }
-                                                           failure:^(NSError *error) {
-                                                               NSLog(@"Error: %@", error);
-                                                               NSString* ErrorResponse = [[NSString alloc] initWithData:(NSData *)error.userInfo[AFNetworkingOperationFailingURLResponseDataErrorKey] encoding:NSUTF8StringEncoding];
-                                                               NSLog(@"#ncoded = %@",ErrorResponse);
+                                                        }
+                                                        failure:^(NSError *error) {
+                                                            NSLog(@"Error: %@", error);
+                                                            NSString* ErrorResponse = [[NSString alloc] initWithData:(NSData *)error.userInfo[AFNetworkingOperationFailingURLResponseDataErrorKey] encoding:NSUTF8StringEncoding];
+                                                            NSLog(@"#ncoded = %@",ErrorResponse);
 
-                                                               [[Jason client] error];
-                                                           }];
-                }
+                                                            [[Jason client] error];
+                                                        }];
             }
         }
-
-        
     }
     
 }

--- a/app/Jasonette/JasonOauthAction.m
+++ b/app/Jasonette/JasonOauthAction.m
@@ -1011,10 +1011,9 @@
                 
                 [OAuth2Manager authenticateUsingOAuthWithURLString:access_options[@"path"]
                                                         parameters:access_data success:^(AFOAuthCredential *credential) {
-                                                                [AFOAuthCredential storeCredential:credential
-                                                                                    withIdentifier:client_id];
+                                                            [AFOAuthCredential storeCredential:credential withIdentifier:client_id];
+                                                            
                                                             [[Jason client] success];
-
                                                         }
                                                         failure:^(NSError *error) {
                                                             NSLog(@"Error: %@", error);


### PR DESCRIPTION
Some OAuth services, if the auth phase was successful, directly return an access token, like Dropbox or my [facebook login example](http://github.com/snada/jasonette-facebook-login).

The $oauth.auth action right now forces the presence of the "access" key in json, forcing the insertion of scheme, host, path to exchange the authentication code with an access token and a client_id to save the new access_token.

Since this is not going to happen, all of that data is actually discarded, the call would not be made but still be checked for presence.

This code solves this, completely removing this dependency and using the client_id provided in the "authorize" call to store the token.

Before:

```json
{
  "type": "$oauth.auth",
  "options": {
    "version": "2",
    "authorize": {
      "client_id": "FACEBOOK_ID",
      "scheme": "https",
      "host": "www.facebook.com",
      "path": "/v2.8/dialog/oauth",
      "data": {
        "response_type": "code",
        "redirect_uri": "ROOT/callback"
      }
    },
    "access": {
      "client_id": "FACEBOOK_ID",
      "scheme": "https",
      "host": "www.facebook.com",
      "path": "/v2.8/oauth/access_token"
    }
  }
}
```

After:

```json
{
  "type": "$oauth.auth",
  "options": {
    "version": "2",
    "authorize": {
      "client_id": "FACEBOOK_ID",
      "scheme": "https",
      "host": "www.facebook.com",
      "path": "/v2.8/dialog/oauth",
      "data": {
        "response_type": "code",
        "redirect_uri": "ROOT/callback"
      }
    }
  }
}
```

This shouldn't break anything, but if you have existing code to test let me know!