### PR TITLE
Give UITableView Footer Labels Some Padding

### DIFF
--- a/app/Jasonette/Jason.m
+++ b/app/Jasonette/Jason.m
@@ -2474,6 +2474,7 @@
     if(image){
         if(text){
             [item setImageInsets:UIEdgeInsetsMake(0, 0, 0, 0)];
+            [item setTitlePositionAdjustment:UIOffsetMake(0.0, -2.0)];
         } else {
             [item setImageInsets:UIEdgeInsetsMake(7.5, 0, -7.5, 0)];
         }


### PR DESCRIPTION
The bottom footer tabbar looks way too tight on the bottom so I've suggested we add 2 to the padding there.

Before Change:
![image](https://cloud.githubusercontent.com/assets/45482/26122461/97a5e1dc-3a45-11e7-951f-358260700465.png)

After Change:
![image](https://cloud.githubusercontent.com/assets/45482/26122431/763de792-3a45-11e7-8b0e-43d9901e5339.png)
