### PR TITLE
Local file support for buttons, images, menus

### DIFF
--- a/app/Jasonette/Jason.m
+++ b/app/Jasonette/Jason.m
@@ -2043,14 +2043,7 @@
                 
                 if([image_src containsString:@"file://"]){
                     UIImage *localImage = [UIImage imageNamed:[image_src substringFromIndex:7]];
-                    NSDictionary *style = left_menu[@"style"];
-                    if(style[@"color"]){
-                        UIColor *newColor = [JasonHelper colorwithHexString:style[@"color"] alpha:1.0];
-                        UIImage *newImage = [JasonHelper colorize:localImage into:newColor];
-                        [btn setBackgroundImage:newImage forState:UIControlStateNormal];
-                    } else {
-                        [btn setBackgroundImage:localImage forState:UIControlStateNormal];
-                    }
+                    [self setMenuButtonImage:localImage forButton:btn withMenu:left_menu];
                 } else{
                     SDWebImageManager *manager = [SDWebImageManager sharedManager];
                     [manager downloadImageWithURL:[NSURL URLWithString:image_src]
@@ -2060,14 +2053,7 @@
                                         completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
                                             if (image) {
                                                 dispatch_async(dispatch_get_main_queue(), ^{
-                                                    NSDictionary *style = left_menu[@"style"];
-                                                    if(style[@"color"]){
-                                                        UIColor *newColor = [JasonHelper colorwithHexString:style[@"color"] alpha:1.0];
-                                                        UIImage *newImage = [JasonHelper colorize:image into:newColor];
-                                                        [btn setBackgroundImage:newImage forState:UIControlStateNormal];
-                                                    } else {
-                                                        [btn setBackgroundImage:image forState:UIControlStateNormal];
-                                                    }
+                                                    [self setMenuButtonImage:image forButton:btn withMenu:left_menu];//
                                                 });
                                             }
                                         }];
@@ -2117,14 +2103,7 @@
                 
                 if([image_src containsString:@"file://"]){
                     UIImage *localImage = [UIImage imageNamed:[image_src substringFromIndex:7]];
-                    NSDictionary *style = left_menu[@"style"];
-                    if(style[@"color"]){
-                        UIColor *newColor = [JasonHelper colorwithHexString:style[@"color"] alpha:1.0];
-                        UIImage *newImage = [JasonHelper colorize:localImage into:newColor];
-                        [btn setBackgroundImage:newImage forState:UIControlStateNormal];
-                    } else {
-                        [btn setBackgroundImage:localImage forState:UIControlStateNormal];
-                    }
+                    [self setMenuButtonImage:localImage forButton:btn withMenu:left_menu];
                 } else{
                     SDWebImageManager *manager = [SDWebImageManager sharedManager];
                     [manager downloadImageWithURL:[NSURL URLWithString:image_src]
@@ -2134,14 +2113,7 @@
                                         completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
                                             if (image) {
                                                 dispatch_async(dispatch_get_main_queue(), ^{
-                                                    NSDictionary *style = right_menu[@"style"];
-                                                    if(style[@"color"]){
-                                                        UIColor *newColor = [JasonHelper colorwithHexString:style[@"color"] alpha:1.0];
-                                                        UIImage *newImage = [JasonHelper colorize:image into:newColor];
-                                                        [btn setBackgroundImage:newImage forState:UIControlStateNormal];
-                                                    } else {
-                                                        [btn setBackgroundImage:image forState:UIControlStateNormal];
-                                                    }
+                                                    [self setMenuButtonImage:image forButton:btn withMenu:left_menu];
                                                 });
                                             }
                                         }];
@@ -2177,33 +2149,8 @@
                         if(url){
                             
                             if([url containsString:@"file://"]){
-                                
                                 UIImage *localImage = [UIImage imageNamed:[url substringFromIndex:7]];
-                                
-                                CGFloat width = 0;
-                                CGFloat height = 0;
-                                if(style && style[@"width"]){
-                                    width = [((NSString *)style[@"width"]) floatValue];
-                                }
-                                if(style && style[@"height"]){
-                                    height = [((NSString *)style[@"height"]) floatValue];
-                                }
-                                
-                                
-                                if(width == 0){
-                                    width = localImage.size.width;
-                                }
-                                if(height == 0){
-                                    height = localImage.size.height;
-                                }
-                                CGRect frame = CGRectMake(0, 0, width, height);
-                                
-                                UIView *logoView =[[UIView alloc] initWithFrame:frame];
-                                UIImageView *logoImageView = [[UIImageView alloc] initWithImage:localImage];
-                                logoImageView.frame = frame;
-                                
-                                [logoView addSubview:logoImageView];
-                                VC.navigationItem.titleView = logoView;
+                                [self setLogoImage:localImage withStyle:style];
                             } else{
                             
                                 SDWebImageManager *manager = [SDWebImageManager sharedManager];
@@ -2214,31 +2161,7 @@
                                                     completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
                                                         if (image) {
                                                             dispatch_async(dispatch_get_main_queue(), ^{
-                                                                CGFloat width = 0;
-                                                                CGFloat height = 0;
-                                                                if(style && style[@"width"]){
-                                                                    width = [((NSString *)style[@"width"]) floatValue];
-                                                                }
-                                                                if(style && style[@"height"]){
-                                                                    height = [((NSString *)style[@"height"]) floatValue];
-                                                                }
-                                                                
-                                                                
-                                                                if(width == 0){
-                                                                    width = image.size.width;
-                                                                }
-                                                                if(height == 0){
-                                                                    height = image.size.height;
-                                                                }
-                                                                CGRect frame = CGRectMake(0, 0, width, height);
-                                                                
-                                                                UIView *logoView =[[UIView alloc] initWithFrame:frame];
-                                                                UIImageView *logoImageView = [[UIImageView alloc] initWithImage:image];
-                                                                logoImageView.frame = frame;
-                                                                
-                                                                [logoView addSubview:logoImageView];
-                                                                VC.navigationItem.titleView = logoView;
-                                                                
+                                                                [self setLogoImage:image withStyle:style];
                                                             });
                                                         }
                                                     }];
@@ -2287,6 +2210,46 @@
     navigationController.navigationBarHidden = NO;
 
 }
+
+- (void)setLogoImage: (UIImage *)image withStyle:(NSDictionary *)style {
+    CGFloat width = 0;
+    CGFloat height = 0;
+    if(style && style[@"width"]){
+        width = [((NSString *)style[@"width"]) floatValue];
+    }
+    if(style && style[@"height"]){
+        height = [((NSString *)style[@"height"]) floatValue];
+    }
+    
+    
+    if(width == 0){
+        width = image.size.width;
+    }
+    if(height == 0){
+        height = image.size.height;
+    }
+    CGRect frame = CGRectMake(0, 0, width, height);
+    
+    UIView *logoView =[[UIView alloc] initWithFrame:frame];
+    UIImageView *logoImageView = [[UIImageView alloc] initWithImage:image];
+    logoImageView.frame = frame;
+    
+    [logoView addSubview:logoImageView];
+    VC.navigationItem.titleView = logoView;
+}
+
+- (UIButton *)setMenuButtonImage: (UIImage *)image forButton: (UIButton *)button withMenu:(NSDictionary *)menu {
+    NSDictionary *style = menu[@"style"];
+    if(style[@"color"]){
+        UIColor *newColor = [JasonHelper colorwithHexString:style[@"color"] alpha:1.0];
+        UIImage *newImage = [JasonHelper colorize:image into:newColor];
+        [button setBackgroundImage:newImage forState:UIControlStateNormal];
+    } else {
+        [button setBackgroundImage:image forState:UIControlStateNormal];
+    }
+    return button;
+}
+
 - (void)setupMenuBadge: (BBBadgeBarButtonItem *)barButton forData: (NSDictionary *)badge_menu{
     if(badge_menu[@"badge"]){
         NSDictionary *badge = badge_menu[@"badge"];

--- a/app/Jasonette/Jason.m
+++ b/app/Jasonette/Jason.m
@@ -2040,25 +2040,39 @@
             btn.frame = CGRectMake(0,0,20,20);
             if(left_menu[@"image"]){
                 NSString *image_src = left_menu[@"image"];
-                SDWebImageManager *manager = [SDWebImageManager sharedManager];
-                [manager downloadImageWithURL:[NSURL URLWithString:image_src]
-                                      options:0
-                                     progress:^(NSInteger receivedSize, NSInteger expectedSize) {
-                                     }
-                                    completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
-                                        if (image) {
-                                            dispatch_async(dispatch_get_main_queue(), ^{
-                                                NSDictionary *style = left_menu[@"style"];
-                                                if(style[@"color"]){
-                                                    UIColor *newColor = [JasonHelper colorwithHexString:style[@"color"] alpha:1.0];
-                                                    UIImage *newImage = [JasonHelper colorize:image into:newColor];
-                                                    [btn setBackgroundImage:newImage forState:UIControlStateNormal];
-                                                } else {
-                                                    [btn setBackgroundImage:image forState:UIControlStateNormal];
-                                                }
-                                            });
-                                        }
-                                    }];
+                
+                if([image_src containsString:@"file://"]){
+                    UIImage *localImage = [UIImage imageNamed:[image_src substringFromIndex:7]];
+                    NSDictionary *style = left_menu[@"style"];
+                    if(style[@"color"]){
+                        UIColor *newColor = [JasonHelper colorwithHexString:style[@"color"] alpha:1.0];
+                        UIImage *newImage = [JasonHelper colorize:localImage into:newColor];
+                        [btn setBackgroundImage:newImage forState:UIControlStateNormal];
+                    } else {
+                        [btn setBackgroundImage:localImage forState:UIControlStateNormal];
+                    }
+                } else{
+                    SDWebImageManager *manager = [SDWebImageManager sharedManager];
+                    [manager downloadImageWithURL:[NSURL URLWithString:image_src]
+                                          options:0
+                                         progress:^(NSInteger receivedSize, NSInteger expectedSize) {
+                                         }
+                                        completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
+                                            if (image) {
+                                                dispatch_async(dispatch_get_main_queue(), ^{
+                                                    NSDictionary *style = left_menu[@"style"];
+                                                    if(style[@"color"]){
+                                                        UIColor *newColor = [JasonHelper colorwithHexString:style[@"color"] alpha:1.0];
+                                                        UIImage *newImage = [JasonHelper colorize:image into:newColor];
+                                                        [btn setBackgroundImage:newImage forState:UIControlStateNormal];
+                                                    } else {
+                                                        [btn setBackgroundImage:image forState:UIControlStateNormal];
+                                                    }
+                                                });
+                                            }
+                                        }];
+                }
+                
             } else {
                 [btn setBackgroundImage:[UIImage imageNamed:@"more"] forState:UIControlStateNormal];
             }
@@ -2100,25 +2114,38 @@
             btn.frame = CGRectMake(0,0,25,25);
             if(right_menu[@"image"]){
                 NSString *image_src = right_menu[@"image"];
-                SDWebImageManager *manager = [SDWebImageManager sharedManager];
-                [manager downloadImageWithURL:[NSURL URLWithString:image_src]
-                                      options:0
-                                     progress:^(NSInteger receivedSize, NSInteger expectedSize) {
-                                     }
-                                    completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
-                                        if (image) {
-                                            dispatch_async(dispatch_get_main_queue(), ^{
-                                                NSDictionary *style = right_menu[@"style"];
-                                                if(style[@"color"]){
-                                                    UIColor *newColor = [JasonHelper colorwithHexString:style[@"color"] alpha:1.0];
-                                                    UIImage *newImage = [JasonHelper colorize:image into:newColor];
-                                                    [btn setBackgroundImage:newImage forState:UIControlStateNormal];
-                                                } else {
-                                                    [btn setBackgroundImage:image forState:UIControlStateNormal];
-                                                }
-                                            });
-                                        }
-                                    }];
+                
+                if([image_src containsString:@"file://"]){
+                    UIImage *localImage = [UIImage imageNamed:[image_src substringFromIndex:7]];
+                    NSDictionary *style = left_menu[@"style"];
+                    if(style[@"color"]){
+                        UIColor *newColor = [JasonHelper colorwithHexString:style[@"color"] alpha:1.0];
+                        UIImage *newImage = [JasonHelper colorize:localImage into:newColor];
+                        [btn setBackgroundImage:newImage forState:UIControlStateNormal];
+                    } else {
+                        [btn setBackgroundImage:localImage forState:UIControlStateNormal];
+                    }
+                } else{
+                    SDWebImageManager *manager = [SDWebImageManager sharedManager];
+                    [manager downloadImageWithURL:[NSURL URLWithString:image_src]
+                                          options:0
+                                         progress:^(NSInteger receivedSize, NSInteger expectedSize) {
+                                         }
+                                        completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
+                                            if (image) {
+                                                dispatch_async(dispatch_get_main_queue(), ^{
+                                                    NSDictionary *style = right_menu[@"style"];
+                                                    if(style[@"color"]){
+                                                        UIColor *newColor = [JasonHelper colorwithHexString:style[@"color"] alpha:1.0];
+                                                        UIImage *newImage = [JasonHelper colorize:image into:newColor];
+                                                        [btn setBackgroundImage:newImage forState:UIControlStateNormal];
+                                                    } else {
+                                                        [btn setBackgroundImage:image forState:UIControlStateNormal];
+                                                    }
+                                                });
+                                            }
+                                        }];
+                }
             } else {
                 [btn setBackgroundImage:[UIImage imageNamed:@"more"] forState:UIControlStateNormal];
             }
@@ -2148,42 +2175,74 @@
                         NSString *url = titleDict[@"url"];
                         NSDictionary *style = titleDict[@"style"];
                         if(url){
-                            SDWebImageManager *manager = [SDWebImageManager sharedManager];
-                            [manager downloadImageWithURL:[NSURL URLWithString:url]
-                                                  options:0
-                                                 progress:^(NSInteger receivedSize, NSInteger expectedSize) {
-                                                 }
-                                                completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
-                                                    if (image) {
-                                                        dispatch_async(dispatch_get_main_queue(), ^{
-                                                            CGFloat width = 0;
-                                                            CGFloat height = 0;
-                                                            if(style && style[@"width"]){
-                                                                width = [((NSString *)style[@"width"]) floatValue];
-                                                            }
-                                                            if(style && style[@"height"]){
-                                                                height = [((NSString *)style[@"height"]) floatValue];
-                                                            }
-                                                            
-                                                            
-                                                            if(width == 0){
-                                                                width = image.size.width;
-                                                            }
-                                                            if(height == 0){
-                                                                height = image.size.height;
-                                                            }
-                                                            CGRect frame = CGRectMake(0, 0, width, height);
-                                                            
-                                                            UIView *logoView =[[UIView alloc] initWithFrame:frame];
-                                                            UIImageView *logoImageView = [[UIImageView alloc] initWithImage:image];
-                                                            logoImageView.frame = frame;
-                                                            
-                                                            [logoView addSubview:logoImageView];
-                                                            VC.navigationItem.titleView = logoView;
-                                                            
-                                                        });
-                                                    }
-                                                }];
+                            
+                            if([url containsString:@"file://"]){
+                                
+                                UIImage *localImage = [UIImage imageNamed:[url substringFromIndex:7]];
+                                
+                                CGFloat width = 0;
+                                CGFloat height = 0;
+                                if(style && style[@"width"]){
+                                    width = [((NSString *)style[@"width"]) floatValue];
+                                }
+                                if(style && style[@"height"]){
+                                    height = [((NSString *)style[@"height"]) floatValue];
+                                }
+                                
+                                
+                                if(width == 0){
+                                    width = localImage.size.width;
+                                }
+                                if(height == 0){
+                                    height = localImage.size.height;
+                                }
+                                CGRect frame = CGRectMake(0, 0, width, height);
+                                
+                                UIView *logoView =[[UIView alloc] initWithFrame:frame];
+                                UIImageView *logoImageView = [[UIImageView alloc] initWithImage:localImage];
+                                logoImageView.frame = frame;
+                                
+                                [logoView addSubview:logoImageView];
+                                VC.navigationItem.titleView = logoView;
+                            } else{
+                            
+                                SDWebImageManager *manager = [SDWebImageManager sharedManager];
+                                [manager downloadImageWithURL:[NSURL URLWithString:url]
+                                                      options:0
+                                                     progress:^(NSInteger receivedSize, NSInteger expectedSize) {
+                                                     }
+                                                    completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
+                                                        if (image) {
+                                                            dispatch_async(dispatch_get_main_queue(), ^{
+                                                                CGFloat width = 0;
+                                                                CGFloat height = 0;
+                                                                if(style && style[@"width"]){
+                                                                    width = [((NSString *)style[@"width"]) floatValue];
+                                                                }
+                                                                if(style && style[@"height"]){
+                                                                    height = [((NSString *)style[@"height"]) floatValue];
+                                                                }
+                                                                
+                                                                
+                                                                if(width == 0){
+                                                                    width = image.size.width;
+                                                                }
+                                                                if(height == 0){
+                                                                    height = image.size.height;
+                                                                }
+                                                                CGRect frame = CGRectMake(0, 0, width, height);
+                                                                
+                                                                UIView *logoView =[[UIView alloc] initWithFrame:frame];
+                                                                UIImageView *logoImageView = [[UIImageView alloc] initWithImage:image];
+                                                                logoImageView.frame = frame;
+                                                                
+                                                                [logoView addSubview:logoImageView];
+                                                                VC.navigationItem.titleView = logoView;
+                                                                
+                                                            });
+                                                        }
+                                                    }];
+                            }
                         }
                         
                     } else if([titleDict[@"type"] isEqualToString:@"label"]) {
@@ -2490,43 +2549,55 @@
         } else {
             [item setImageInsets:UIEdgeInsetsMake(7.5, 0, -7.5, 0)];
         }
-        [manager downloadImageWithURL:[NSURL URLWithString:image]
-                              options:0
-                             progress:^(NSInteger receivedSize, NSInteger expectedSize) {
-                             }
-                            completed:^(UIImage *i, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
-                                if (i) {
-                                    CGFloat width = 0;
-                                    CGFloat height = 0;
-                                    if(tab[@"style"] && tab[@"style"][@"width"]){
-                                        width = [tab[@"style"][@"width"] floatValue];
+        
+        if([image containsString:@"file://"]){
+            UIImage *i = [UIImage imageNamed:[image substringFromIndex:7]];
+            [self setTabImage:i withTab:tab andItem:item];
+        } else{
+            [manager downloadImageWithURL:[NSURL URLWithString:image]
+                                  options:0
+                                 progress:^(NSInteger receivedSize, NSInteger expectedSize) {
+                                 }
+                                completed:^(UIImage *i, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
+                                    if (i) {
+                                        [self setTabImage:i withTab:tab andItem:item];
                                     }
-                                    if(tab[@"style"] && tab[@"style"][@"height"]){
-                                        height = [tab[@"style"][@"height"] floatValue];
-                                    }
-                                    
-                                    if(width == 0 && height !=0){
-                                        width = height;
-                                    } else if (width != 0 && height ==0){
-                                        height = width;
-                                    } else if (width == 0 && height ==0){
-                                        width = 30;
-                                        height = 30;
-                                    }
-                                    
-                                    UIImage *newImage = [JasonHelper scaleImage:i ToSize:CGSizeMake(width,height)];
-                                    dispatch_async(dispatch_get_main_queue(), ^{
-                                        [item setImage:newImage];
-                                    });
-                                }
-                            }];
+                                }];
 
+        }
+        
     } else {
         [item setTitlePositionAdjustment:UIOffsetMake(0.0, -18.0)];
     }
     if(badge){
         [item setBadgeValue:badge];
     }
+}
+
+- (void)setTabImage:(UIImage*)image withTab:(NSDictionary*)tab andItem:(UITabBarItem*)item {
+    CGFloat width = 0;
+    CGFloat height = 0;
+    if(tab[@"style"] && tab[@"style"][@"width"]){
+        width = [tab[@"style"][@"width"] floatValue];
+    }
+    if(tab[@"style"] && tab[@"style"][@"height"]){
+        height = [tab[@"style"][@"height"] floatValue];
+    }
+    
+    if(width == 0 && height !=0){
+        width = height;
+    } else if (width != 0 && height ==0){
+        height = width;
+    } else if (width == 0 && height ==0){
+        width = 30;
+        height = 30;
+    }
+    
+    UIImage *newImage = [JasonHelper scaleImage:image ToSize:CGSizeMake(width,height)];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [item setImage:newImage];
+    });
+
 }
 
 # pragma mark - View Event Handlers

--- a/app/Jasonette/JasonButtonComponent.m
+++ b/app/Jasonette/JasonButtonComponent.m
@@ -48,20 +48,38 @@
         UIImageView * imageView = [[UIImageView alloc] init];
         
         if(![url containsString:@"{{"] && ![url containsString:@"}}"]){
-            [imageView sd_setImageWithURL:[NSURL URLWithString:url] placeholderImage:placeholder_image completed:^(UIImage *i, NSError *error, SDImageCacheType cacheType, NSURL *imageURL) {
-                if(!error){
-                    JasonComponentFactory.imageLoaded[url] = [NSValue valueWithCGSize:i.size];
-                    if(style[@"color"]){
-                        NSString *colorHex = style[@"color"];
-                        UIColor *c = [JasonHelper colorwithHexString:colorHex alpha:1.0];
-                        UIImage *image = [imageView.image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
-                        [component setTintColor:c];
-                        [component setImage: image forState:UIControlStateNormal];
-                    } else {
-                        [component setImage:imageView.image forState:UIControlStateNormal];
-                    }
+            
+            if([url containsString:@"file://"]){
+                NSString *localImageName = [url substringFromIndex:7];
+                UIImage *localImage = [UIImage imageNamed:localImageName];
+                
+                if(style[@"color"]){
+                    NSString *colorHex = style[@"color"];
+                    UIColor *c = [JasonHelper colorwithHexString:colorHex alpha:1.0];
+                    UIImage *image = [localImage imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+                    [component setTintColor:c];
+                    [component setImage:image forState:UIControlStateNormal];
+                } else {
+                    [component setImage:localImage forState:UIControlStateNormal];
                 }
-            }];
+                                
+                JasonComponentFactory.imageLoaded[url] = [NSValue valueWithCGSize:localImage.size];
+            } else{
+                [imageView sd_setImageWithURL:[NSURL URLWithString:url] placeholderImage:placeholder_image completed:^(UIImage *i, NSError *error, SDImageCacheType cacheType, NSURL *imageURL) {
+                    if(!error){
+                        JasonComponentFactory.imageLoaded[url] = [NSValue valueWithCGSize:i.size];
+                        if(style[@"color"]){
+                            NSString *colorHex = style[@"color"];
+                            UIColor *c = [JasonHelper colorwithHexString:colorHex alpha:1.0];
+                            UIImage *image = [imageView.image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+                            [component setTintColor:c];
+                            [component setImage: image forState:UIControlStateNormal];
+                        } else {
+                            [component setImage:imageView.image forState:UIControlStateNormal];
+                        }
+                    }
+                }];
+            }
         }
         [component setTitle:@"" forState:UIControlStateNormal];
         

--- a/app/Jasonette/JasonImageComponent.m
+++ b/app/Jasonette/JasonImageComponent.m
@@ -19,7 +19,6 @@
     UIImage *placeholder_image = [UIImage imageNamed:@"placeholderr"];
     NSString *url = (NSString *)[JasonHelper cleanNull: json[@"url"] type:@"string"];
     
-    
     SDWebImageDownloader *manager = [SDWebImageManager sharedManager].imageDownloader;
     NSDictionary *session = [JasonHelper sessionForUrl:url];
     if(session && session.count > 0 && session[@"header"]){
@@ -36,11 +35,20 @@
     if(![url containsString:@"{{"] && ![url containsString:@"}}"]){
         [component setIndicatorStyle:UIActivityIndicatorViewStyleGray];
         [component setShowActivityIndicatorView:YES];
-        [component sd_setImageWithURL:[NSURL URLWithString:url] placeholderImage:placeholder_image completed:^(UIImage *i, NSError *error, SDImageCacheType cacheType, NSURL *imageURL) {
-            if(!error){
-                JasonComponentFactory.imageLoaded[url] = [NSValue valueWithCGSize:i.size];
-            }
-        }];
+        
+        if([url containsString:@"file://"]){
+            NSString *localImageName = [url substringFromIndex:7];
+            UIImage *localImage = [UIImage imageNamed:localImageName];
+            [component setImage:[UIImage imageNamed:localImageName]];
+            JasonComponentFactory.imageLoaded[url] = [NSValue valueWithCGSize:localImage.size];
+        } else{
+            [component sd_setImageWithURL:[NSURL URLWithString:url] placeholderImage:placeholder_image completed:^(UIImage *i, NSError *error, SDImageCacheType cacheType, NSURL *imageURL) {
+                if(!error){
+                    JasonComponentFactory.imageLoaded[url] = [NSValue valueWithCGSize:i.size];
+                }
+            }];
+        }
+        
     }
     
     // Before applying common styles, Update the style attribute based on the fetched image dimension (different from other components)


### PR DESCRIPTION
This allows users to use file:// prefix on what used to be all remote files for images within the Jasonette framework so that images files don’t have to be downloaded in cases where it’s static content for the mobile app.