### PR TITLE
Global space key-value storage cache

### DIFF
--- a/app/Jasonette/JasonGlobalAction.h
+++ b/app/Jasonette/JasonGlobalAction.h
@@ -1,5 +1,5 @@
 //
-//  Cache.h
+//  JasonGlobalAction.h
 //  Jasonette
 //
 //  Copyright © 2016 gliechtenstein. All rights reserved.

--- a/app/Jasonette/JasonGlobalAction.h
+++ b/app/Jasonette/JasonGlobalAction.h
@@ -1,0 +1,10 @@
+//
+//  Cache.h
+//  Jasonette
+//
+//  Copyright © 2016 gliechtenstein. All rights reserved.
+//
+#import "JasonAction.h"
+#import "JasonHelper.h"
+@interface JasonGlobalAction : JasonAction
+@end

--- a/app/Jasonette/JasonGlobalAction.m
+++ b/app/Jasonette/JasonGlobalAction.m
@@ -1,5 +1,5 @@
 //
-//  Cache.m
+//  JasonGlobalAction.m
 //  Jasonette
 //
 //  Copyright © 2016 gliechtenstein. All rights reserved.

--- a/app/Jasonette/JasonGlobalAction.m
+++ b/app/Jasonette/JasonGlobalAction.m
@@ -1,0 +1,54 @@
+//
+//  Cache.m
+//  Jasonette
+//
+//  Copyright © 2016 gliechtenstein. All rights reserved.
+//
+#import "JasonGlobalAction.h"
+
+@implementation JasonGlobalAction
+- (void)reset{
+    
+    NSString *normalized_url = @"global";
+    NSMutableDictionary *set = [[NSMutableDictionary alloc] init];
+    [[NSUserDefaults standardUserDefaults] setObject:set forKey:normalized_url];
+    [[NSUserDefaults standardUserDefaults] synchronize];
+    self.VC.current_cache = set;
+    [[Jason client] success: set];
+    
+}
+/*
+ + (NSDictionary *)get:(NSString *)url{
+ NSString *normalized_url = [url lowercaseString];
+ return [[NSUserDefaults standardUserDefaults] objectForKey:normalized_url];
+ }
+ */
+- (void)set{
+    if([[self.options description] containsString:@"{{"] && [[self.options description] containsString:@"}}"]){
+        [[Jason client] error];
+        return;
+    }
+    
+    @try {
+        NSString *normalized_url = @"global";
+        NSDictionary *to_set = [[NSUserDefaults standardUserDefaults] objectForKey:normalized_url];
+        NSMutableDictionary *mutated;
+        if(to_set && to_set.count > 0){
+            mutated = [to_set mutableCopy];
+            for(NSString *key in self.options){
+                mutated[key] = self.options[key];
+            }
+        } else {
+            mutated = [self.options mutableCopy];
+        }
+        [[NSUserDefaults standardUserDefaults] setObject:mutated forKey:normalized_url];
+        [[NSUserDefaults standardUserDefaults] synchronize];
+        
+        self.VC.current_cache = mutated;
+        [[Jason client] success: mutated];
+    } @catch (NSException *e){
+        [[Jason client] error];
+    }
+    
+}
+@end


### PR DESCRIPTION
@gliechtenstein I know that we have $cache for a per-view persistence, but why aren't we able to drop stuff into the global space? Am I just not seeing where this can be done yet?

I've opened this as more of a discussion, but let me know what you're thinking of doing please.