### PR TITLE
Supporting Shadows and Rounded Corners on Images and Buttons

### DIFF
--- a/app/Jasonette/Jason.m
+++ b/app/Jasonette/Jason.m
@@ -2033,11 +2033,13 @@
             }
         }
     } else {
+        
+        NSDictionary *style = left_menu[@"style"];
         if(left_menu[@"text"]){
             UIButton *button = [[UIButton alloc] init];
             [button setTitle:left_menu[@"text"] forState:UIControlStateNormal];
             [button setTitle:left_menu[@"text"] forState:UIControlStateFocused];
-            NSDictionary *style = left_menu[@"style"];
+            
             if(style && style[@"color"]){
                 UIColor *c = [JasonHelper colorwithHexString:style[@"color"] alpha:1.0];
                 [button setTitleColor:c forState:UIControlStateNormal];
@@ -2062,9 +2064,20 @@
             if(left_menu[@"image"]){
                 NSString *image_src = left_menu[@"image"];
                 
+                float cornerRadius = [style[@"corner_radius"] floatValue];
+                CGSize size = CGSizeMake(40, 40);
+                
                 if([image_src containsString:@"file://"]){                    
                     UIImage *localImage = [UIImage imageNamed:[image_src substringFromIndex:7]];
-                    [self setMenuButtonImage:localImage forButton:btn withMenu:left_menu];
+                    
+                    if(cornerRadius > 0) {
+                        UIImage *newImage = [JasonHelper getRoundedImage:localImage withCornerRadius:cornerRadius andSize:size andStyle:style];
+                        [JasonHelper addShadowToButton:btn withStyle:style];
+                        [self setMenuButtonImage:newImage forButton:btn withMenu:left_menu];
+                    } else {
+                        [self setMenuButtonImage:localImage forButton:btn withMenu:left_menu];
+                    }
+
                 } else{
                     SDWebImageManager *manager = [SDWebImageManager sharedManager];
                     [manager downloadImageWithURL:[NSURL URLWithString:image_src]
@@ -2074,7 +2087,15 @@
                                         completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
                                             if (image) {
                                                 dispatch_async(dispatch_get_main_queue(), ^{
-                                                    [self setMenuButtonImage:image forButton:btn withMenu:left_menu];//
+                                                    
+                                                    if(cornerRadius > 0) {
+                                                        UIImage *newImage = [JasonHelper getRoundedImage:image withCornerRadius:cornerRadius andSize:size andStyle:style];
+                                                        [JasonHelper addShadowToButton:btn withStyle:style];
+                                                        [self setMenuButtonImage:newImage forButton:btn withMenu:left_menu];
+                                                    } else {
+                                                        [self setMenuButtonImage:image forButton:btn withMenu:left_menu];
+                                                    }
+                                                    
                                                 });
                                             }
                                         }];

--- a/app/Jasonette/Jason.m
+++ b/app/Jasonette/Jason.m
@@ -2125,12 +2125,13 @@
                 NSString *image_src = right_menu[@"image"];
                 
                 float cornerRadius = [style[@"corner_radius"] floatValue];
+                CGSize size = CGSizeMake(40, 40);
                 
                 if([image_src containsString:@"file://"]){
                     UIImage *localImage = [UIImage imageNamed:[image_src substringFromIndex:7]];
                     
                     if(cornerRadius > 0) {
-                        UIImage *newImage = [JasonHelper getRoundedImage:localImage withCornerRadius:cornerRadius andStyle:style];
+                        UIImage *newImage = [JasonHelper getRoundedImage:localImage withCornerRadius:cornerRadius andSize:size andStyle:style];
                         [JasonHelper addShadowToButton:btn withStyle:style];
                         [self setMenuButtonImage:newImage forButton:btn withMenu:left_menu];
                     } else {
@@ -2148,7 +2149,7 @@
                                                 dispatch_async(dispatch_get_main_queue(), ^{
                                                     
                                                     if(cornerRadius > 0) {
-                                                        UIImage *newImage = [JasonHelper getRoundedImage:image withCornerRadius:cornerRadius andStyle:style];
+                                                        UIImage *newImage = [JasonHelper getRoundedImage:image withCornerRadius:cornerRadius andSize:size andStyle:style];
                                                         [JasonHelper addShadowToButton:btn withStyle:style];
                                                         [self setMenuButtonImage:newImage forButton:btn withMenu:left_menu];
                                                     } else {

--- a/app/Jasonette/Jason.m
+++ b/app/Jasonette/Jason.m
@@ -2058,7 +2058,7 @@
             leftBarButton = [[BBBadgeBarButtonItem alloc] initWithCustomUIButton:button];
         } else {
             UIButton *btn =  [UIButton buttonWithType:UIButtonTypeCustom];
-            btn.frame = CGRectMake(0,0,20,20);
+            btn.frame = CGRectMake(0,0,20,20);            
             if(left_menu[@"image"]){
                 NSString *image_src = left_menu[@"image"];
                 
@@ -2124,9 +2124,19 @@
             if(right_menu[@"image"]){
                 NSString *image_src = right_menu[@"image"];
                 
+                float cornerRadius = [style[@"corner_radius"] floatValue];
+                
                 if([image_src containsString:@"file://"]){
                     UIImage *localImage = [UIImage imageNamed:[image_src substringFromIndex:7]];
-                    [self setMenuButtonImage:localImage forButton:btn withMenu:left_menu];
+                    
+                    if(cornerRadius > 0) {
+                        UIImage *newImage = [JasonHelper getRoundedImage:localImage withCornerRadius:cornerRadius andStyle:style];
+                        [JasonHelper addShadowToButton:btn withStyle:style];
+                        [self setMenuButtonImage:newImage forButton:btn withMenu:left_menu];
+                    } else {
+                        [self setMenuButtonImage:localImage forButton:btn withMenu:left_menu];
+                    }
+                    
                 } else{
                     SDWebImageManager *manager = [SDWebImageManager sharedManager];
                     [manager downloadImageWithURL:[NSURL URLWithString:image_src]
@@ -2137,43 +2147,9 @@
                                             if (image) {
                                                 dispatch_async(dispatch_get_main_queue(), ^{
                                                     
-                                                    if([style[@"shape"] isEqualToString:@"circle"]) {
-                                                        
-                                                        // Rounded circle button
-                                                        CGRect rect = CGRectMake(0, 0, 40, 40);
-                                                        
-                                                        // Border
-                                                        UIGraphicsBeginImageContextWithOptions(CGSizeMake(40, 40), NO, 1.0); {
-                                                            
-                                                            // Set border defaults if not specified
-                                                            float borderOpacity = style[@"border_opacity"] ? [style[@"border_opacity"] floatValue] : 1.0f;
-                                                            UIColor *borderColor = style[@"border_color"] ? [JasonHelper colorwithHexString:style[@"border_color"] alpha:borderOpacity] : [UIColor blackColor];
-                                                            float borderWidth = style[@"border_width"] ? [style[@"border_width"] floatValue] : 0.0f;
-                                                            
-                                                            [borderColor setFill];
-                                                            [[UIBezierPath bezierPathWithOvalInRect:rect] fill];
-                                                            
-                                                            CGRect interiorBox = CGRectInset(rect, borderWidth, borderWidth);
-                                                            UIBezierPath *interior = [UIBezierPath bezierPathWithOvalInRect:interiorBox];
-                                                            [interior addClip];
-                                                            [image drawInRect:rect];
-                                                        }
-                                                        
-                                                        UIImage *newImage = UIGraphicsGetImageFromCurrentImageContext();
-                                                        UIGraphicsEndImageContext();
-                                                        
-                                                        // Shadow
-                                                        float shadowOpacity = style[@"shadow_opacity"] ? [style[@"shadow_opacity"] floatValue] : 1.0f;
-                                                        UIColor *shadowColor = style[@"shadow_color"] ? [JasonHelper colorwithHexString:style[@"shadow_color"]  alpha:shadowOpacity] : [UIColor blackColor];
-                                                        float shadowWidth = style[@"shadow_width"] ? [style[@"shadow_width"] floatValue] : 0.0f;
-                                                        
-                                                        [btn.layer setShadowColor:[shadowColor CGColor]];
-                                                        [btn.layer setShadowOffset:CGSizeMake(0, shadowWidth)];
-                                                        [btn.layer setMasksToBounds:NO];
-                                                        [btn.layer setShadowRadius:shadowWidth];
-                                                        [btn.layer setShadowOpacity:shadowOpacity];
-                                                        [btn.layer setCornerRadius:20];
-                                                        
+                                                    if(cornerRadius > 0) {
+                                                        UIImage *newImage = [JasonHelper getRoundedImage:image withCornerRadius:cornerRadius andStyle:style];
+                                                        [JasonHelper addShadowToButton:btn withStyle:style];
                                                         [self setMenuButtonImage:newImage forButton:btn withMenu:left_menu];
                                                     } else {
                                                         [self setMenuButtonImage:image forButton:btn withMenu:left_menu];

--- a/app/Jasonette/Jason.m
+++ b/app/Jasonette/Jason.m
@@ -2084,6 +2084,7 @@
                 [btn setBackgroundImage:[UIImage imageNamed:@"more"] forState:UIControlStateNormal];
             }
             [btn addTarget:self action:@selector(leftMenu) forControlEvents:UIControlEventTouchUpInside];
+            
             leftBarButton = [[BBBadgeBarButtonItem alloc] initWithCustomUIButton:btn];
         }
         [self setupMenuBadge:leftBarButton forData:left_menu];
@@ -2093,11 +2094,11 @@
     if(!right_menu || [right_menu count] == 0){
         rightBarButton = nil;
     } else {
+        NSDictionary *style = right_menu[@"style"];
         if(right_menu[@"text"]){
             UIButton *button = [[UIButton alloc] init];
             [button setTitle:right_menu[@"text"] forState:UIControlStateNormal];
             [button setTitle:right_menu[@"text"] forState:UIControlStateFocused];
-            NSDictionary *style = right_menu[@"style"];
             if(style && style[@"color"]){
                 UIColor *c = [JasonHelper colorwithHexString:style[@"color"] alpha:1.0];
                 [button setTitleColor:c forState:UIControlStateNormal];
@@ -2119,6 +2120,7 @@
         } else {
             UIButton *btn =  [UIButton buttonWithType:UIButtonTypeCustom];
             btn.frame = CGRectMake(0,0,25,25);
+            
             if(right_menu[@"image"]){
                 NSString *image_src = right_menu[@"image"];
                 
@@ -2134,7 +2136,49 @@
                                         completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
                                             if (image) {
                                                 dispatch_async(dispatch_get_main_queue(), ^{
-                                                    [self setMenuButtonImage:image forButton:btn withMenu:left_menu];
+                                                    
+                                                    if([style[@"shape"] isEqualToString:@"circle"]) {
+                                                        
+                                                        // Rounded circle button
+                                                        CGRect rect = CGRectMake(0, 0, 40, 40);
+                                                        
+                                                        // Border
+                                                        UIGraphicsBeginImageContextWithOptions(CGSizeMake(40, 40), NO, 1.0); {
+                                                            
+                                                            // Set border defaults if not specified
+                                                            float borderOpacity = style[@"border_opacity"] ? [style[@"border_opacity"] floatValue] : 1.0f;
+                                                            UIColor *borderColor = style[@"border_color"] ? [JasonHelper colorwithHexString:style[@"border_color"] alpha:borderOpacity] : [UIColor blackColor];
+                                                            float borderWidth = style[@"border_width"] ? [style[@"border_width"] floatValue] : 0.0f;
+                                                            
+                                                            [borderColor setFill];
+                                                            [[UIBezierPath bezierPathWithOvalInRect:rect] fill];
+                                                            
+                                                            CGRect interiorBox = CGRectInset(rect, borderWidth, borderWidth);
+                                                            UIBezierPath *interior = [UIBezierPath bezierPathWithOvalInRect:interiorBox];
+                                                            [interior addClip];
+                                                            [image drawInRect:rect];
+                                                        }
+                                                        
+                                                        UIImage *newImage = UIGraphicsGetImageFromCurrentImageContext();
+                                                        UIGraphicsEndImageContext();
+                                                        
+                                                        // Shadow
+                                                        float shadowOpacity = style[@"shadow_opacity"] ? [style[@"shadow_opacity"] floatValue] : 1.0f;
+                                                        UIColor *shadowColor = style[@"shadow_color"] ? [JasonHelper colorwithHexString:style[@"shadow_color"]  alpha:shadowOpacity] : [UIColor blackColor];
+                                                        float shadowWidth = style[@"shadow_width"] ? [style[@"shadow_width"] floatValue] : 0.0f;
+                                                        
+                                                        [btn.layer setShadowColor:[shadowColor CGColor]];
+                                                        [btn.layer setShadowOffset:CGSizeMake(0, shadowWidth)];
+                                                        [btn.layer setMasksToBounds:NO];
+                                                        [btn.layer setShadowRadius:shadowWidth];
+                                                        [btn.layer setShadowOpacity:shadowOpacity];
+                                                        [btn.layer setCornerRadius:20];
+                                                        
+                                                        [self setMenuButtonImage:newImage forButton:btn withMenu:left_menu];
+                                                    } else {
+                                                        [self setMenuButtonImage:image forButton:btn withMenu:left_menu];
+                                                    }
+                                                    
                                                 });
                                             }
                                         }];

--- a/app/Jasonette/JasonHelper.h
+++ b/app/Jasonette/JasonHelper.h
@@ -41,4 +41,6 @@
 + (NSString *)getSignature: (NSDictionary *)item;
 + (NSArray *)childOf: (UIView *)view withClassName: (NSString *)className;
 + (id) read_local_json: (NSString *)url;
++ (UIImage *)getRoundedImage: (UIImage *)image withCornerRadius:(float)cornerRadius andStyle: (NSDictionary *)style;
++ (void)addShadowToButton: (UIButton *)btn withStyle:(NSDictionary *)style;
 @end

--- a/app/Jasonette/JasonHelper.h
+++ b/app/Jasonette/JasonHelper.h
@@ -41,6 +41,6 @@
 + (NSString *)getSignature: (NSDictionary *)item;
 + (NSArray *)childOf: (UIView *)view withClassName: (NSString *)className;
 + (id) read_local_json: (NSString *)url;
-+ (UIImage *)getRoundedImage: (UIImage *)image withCornerRadius:(float)cornerRadius andStyle: (NSDictionary *)style;
++ (UIImage *)getRoundedImage: (UIImage *)image withCornerRadius:(float)cornerRadius andSize:(CGSize)size andStyle: (NSDictionary *)style;
 + (void)addShadowToButton: (UIButton *)btn withStyle:(NSDictionary *)style;
 @end

--- a/app/Jasonette/JasonHelper.m
+++ b/app/Jasonette/JasonHelper.m
@@ -922,12 +922,12 @@
     return ret;
 }
 
-+ (UIImage *) getRoundedImage:(UIImage *)image withCornerRadius:(float)cornerRadius andStyle:(NSDictionary *)style {
-    // Rounded button
-    CGRect rect = CGRectMake(0, 0, 40, 40);
++ (UIImage *) getRoundedImage:(UIImage *)image withCornerRadius:(float)cornerRadius andSize:(CGSize)size andStyle:(NSDictionary *)style {
+    
+    CGRect rect = CGRectMake(0, 0, size.width, size.height);
     
     // Border
-    UIGraphicsBeginImageContextWithOptions(CGSizeMake(40, 40), NO, 1.0); {
+    UIGraphicsBeginImageContextWithOptions(size, NO, image.scale); {
         
         // Set border defaults if not specified
         float borderOpacity = style[@"border_opacity"] ? [style[@"border_opacity"] floatValue] : 1.0f;

--- a/app/Jasonette/JasonHelper.m
+++ b/app/Jasonette/JasonHelper.m
@@ -922,4 +922,50 @@
     return ret;
 }
 
++ (UIImage *) getRoundedImage:(UIImage *)image withCornerRadius:(float)cornerRadius andStyle:(NSDictionary *)style {
+    // Rounded button
+    CGRect rect = CGRectMake(0, 0, 40, 40);
+    
+    // Border
+    UIGraphicsBeginImageContextWithOptions(CGSizeMake(40, 40), NO, 1.0); {
+        
+        // Set border defaults if not specified
+        float borderOpacity = style[@"border_opacity"] ? [style[@"border_opacity"] floatValue] : 1.0f;
+        UIColor *borderColor = style[@"border_color"] ? [JasonHelper colorwithHexString:style[@"border_color"] alpha:borderOpacity] : [UIColor blackColor];
+        float borderWidth = style[@"border_width"] ? [style[@"border_width"] floatValue] : 0.0f;
+        
+        [borderColor setFill];
+        [[UIBezierPath bezierPathWithRoundedRect:rect cornerRadius:cornerRadius] fill];
+        
+        CGRect interiorBox = CGRectInset(rect, borderWidth, borderWidth);
+        UIBezierPath *interior = [UIBezierPath bezierPathWithRoundedRect:interiorBox cornerRadius:cornerRadius];
+        //UIBezierPath *interior = [UIBezierPath bezierPathWithOvalInRect:interiorBox];
+        [interior addClip];
+        [image drawInRect:rect];
+    }
+    
+    UIImage *newImage = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    
+    return newImage;
+}
+
++ (void) addShadowToButton:(UIButton *)btn withStyle:(NSDictionary *)style {
+    
+    // Shadow
+    float shadowOpacity = style[@"shadow_opacity"] ? [style[@"shadow_opacity"] floatValue] : 1.0f;
+    UIColor *shadowColor = style[@"shadow_color"] ? [JasonHelper colorwithHexString:style[@"shadow_color"]  alpha:shadowOpacity] : [UIColor blackColor];
+    float shadowRadius = style[@"shadow_radius"] ? [style[@"shadow_radius"] floatValue] : 0.0f;
+    float shadowOffsetX = style[@"shadow_offsetx"] ? [style[@"shadow_offsetx"] floatValue] : 0.0f;
+    float shadowOffsetY = style[@"shadow_offsety"] ? [style[@"shadow_offsety"] floatValue] : 0.0f;
+    
+    [btn.layer setShadowColor:[shadowColor CGColor]];
+    [btn.layer setShadowOffset:CGSizeMake(shadowOffsetX, shadowOffsetY)];
+    [btn.layer setMasksToBounds:NO];
+    [btn.layer setShadowRadius:shadowRadius];
+    [btn.layer setShadowOpacity:shadowOpacity];    
+
+}
+
+
 @end


### PR DESCRIPTION
This is a proposed idea based on a need we have on our project. 

I've first pushed code to demonstrate for right-menu buttons, but this could apply to any image and/or layer and left menu as well.

It supports borders and drop shadows.

For your component you must specify certain attributes in the style section.

These are the ones supported by my code submission. There are defaults for all except the shape, which of course by default would just be the normal square shape.

```
"style": {
          "shape": "circle",
          "border_color": "#ffffff",
          "border_width": "2",
          "border_opacity": "1",
          "shadow_color": "#000000",
          "shadow_width": "2",
          "shadow_opacity": "0.5"
      }
```

An example of this in action is:
![image](https://user-images.githubusercontent.com/45482/27465694-2c1da708-57a3-11e7-9052-6288c0394e7f.png)

