### PR TITLE
Throw an error to the Jason client on bad URL

### DIFF
--- a/app/Jasonette/JasonNetworkAction.m
+++ b/app/Jasonette/JasonNetworkAction.m
@@ -183,6 +183,11 @@
                 [[Jason client] error: nil];
                 return;
             }
+        } else {
+            NSLog(@"Error = URL not specified for $network.request call");
+            [[Jason client] networkLoading:NO with:nil];
+            [[Jason client] error: nil];
+            return;
         }
         
         // Set Header if specified  "header"

--- a/app/Jasonette/JasonNetworkAction.m
+++ b/app/Jasonette/JasonNetworkAction.m
@@ -174,6 +174,17 @@
         // Instantiate with session if needed
         NSDictionary *session = [JasonHelper sessionForUrl:url];
         
+        // Check for valid URL and throw error if invalid
+        if(![url isEqualToString:@""]) {
+            NSURL *urlToCheck = [NSURL URLWithString:url];
+            if(!urlToCheck){
+                NSLog(@"Error = Invalid URL for $network.request call");
+                [[Jason client] networkLoading:NO with:nil];
+                [[Jason client] error: nil];
+                return;
+            }
+        }
+        
         // Set Header if specified  "header"
         NSDictionary *headers = self.options[@"header"];
         // legacy code : headers is deprecated


### PR DESCRIPTION
Any urls that contain bad variable names or other errors just crash the app right now. This would throw error message to the log and error handler.