### PR TITLE
Global should handle all datatypes

### DIFF
--- a/app/Jasonette/Jason.m
+++ b/app/Jasonette/Jason.m
@@ -1507,17 +1507,17 @@
     } else {
         
         id data = [[NSUserDefaults standardUserDefaults] objectForKey:@"$global"];
-        NSDictionary *to_set;
+        NSDictionary *dict;
         BOOL deprecated = ![data isKindOfClass:[NSData class]];
         if(data) {
             if(deprecated) {
                 // string type (old version, will deprecate)
-                to_set = (NSDictionary *)data;
+                dict = (NSDictionary *)data;
             } else {
-                to_set = (NSDictionary*) [NSKeyedUnarchiver unarchiveObjectWithData:data];
+                dict = (NSDictionary*) [NSKeyedUnarchiver unarchiveObjectWithData:data];
             }
-            if(to_set && to_set.count > 0) {
-                data_stub[@"$global"] = to_set;
+            if(dict && dict.count > 0) {
+                data_stub[@"$global"] = dict;
             } else {
                 data_stub[@"$global"] = @{};
             }

--- a/app/Jasonette/Jason.m
+++ b/app/Jasonette/Jason.m
@@ -1505,14 +1505,26 @@
     if(self.global){
         data_stub[@"$global"] = self.global;
     } else {
-        NSDictionary *dict = [[NSUserDefaults standardUserDefaults] objectForKey:@"$global"];
-        if(dict && dict.count > 0){
-            data_stub[@"$global"] = dict;
+        
+        id data = [[NSUserDefaults standardUserDefaults] objectForKey:@"$global"];
+        NSDictionary *to_set;
+        BOOL deprecated = ![data isKindOfClass:[NSData class]];
+        if(data) {
+            if(deprecated) {
+                // string type (old version, will deprecate)
+                to_set = (NSDictionary *)data;
+            } else {
+                to_set = (NSDictionary*) [NSKeyedUnarchiver unarchiveObjectWithData:data];
+            }
+            if(to_set && to_set.count > 0) {
+                data_stub[@"$global"] = to_set;
+            } else {
+                data_stub[@"$global"] = @{};
+            }
         } else {
             data_stub[@"$global"] = @{};
         }
     }
-    
     return data_stub;
 }
 

--- a/app/Jasonette/JasonGlobalAction.m
+++ b/app/Jasonette/JasonGlobalAction.m
@@ -52,7 +52,8 @@
         } else {
             mutated = [@{} mutableCopy];
         }
-        [[NSUserDefaults standardUserDefaults] setObject:mutated forKey:global];
+        NSData *updated = [NSKeyedArchiver archivedDataWithRootObject:mutated];
+        [[NSUserDefaults standardUserDefaults] setObject:updated forKey:global];
         [[NSUserDefaults standardUserDefaults] synchronize];
         
         [Jason client].global = mutated;
@@ -123,14 +124,9 @@
                 mutated = [self.options mutableCopy];
             }
             
-            if(deprecated) {
-                [[NSUserDefaults standardUserDefaults] setObject:mutated forKey:global];
-                [[NSUserDefaults standardUserDefaults] synchronize];
-            } else {
-                NSData *updated = [NSKeyedArchiver archivedDataWithRootObject:mutated];
-                [[NSUserDefaults standardUserDefaults] setObject:updated forKey:global];
-                [[NSUserDefaults standardUserDefaults] synchronize];
-            }
+            NSData *updated = [NSKeyedArchiver archivedDataWithRootObject:mutated];
+            [[NSUserDefaults standardUserDefaults] setObject:updated forKey:global];
+            [[NSUserDefaults standardUserDefaults] synchronize];
 
         } else {
             // first time using global

--- a/app/Jasonette/JasonReturnAction.m
+++ b/app/Jasonette/JasonReturnAction.m
@@ -18,7 +18,11 @@
     // 1. propagate the memory._register to the next action
     // 2. set the stack with the caller's success action
     if(caller[@"success"]){
-        [[Jason client] call: caller[@"success"] with:@{@"$jason": self.options}];
+        if(self.options) {
+            [[Jason client] call: caller[@"success"] with:@{@"$jason": self.options}];
+        } else {
+            [[Jason client] call: caller[@"success"] with:@{@"$jason": @{}}];
+        }
     } else {
         [[Jason client] finish];
     }
@@ -30,7 +34,11 @@
     // 1. propagate the memory._register to the next action
     // 2. set the stack with the caller's success action
     if(caller[@"error"]){
-        [[Jason client] call: caller[@"error"] with:@{@"$jason": self.options}];
+        if(self.options) {
+            [[Jason client] call: caller[@"error"] with:@{@"$jason": self.options}];
+        } else {
+            [[Jason client] call: caller[@"error"] with:@{@"$jason": @{}}];
+        }
     } else {
         [[Jason client] finish];
     }


### PR DESCRIPTION
$global uses NSUserDefaults internally. Because of this it only supports certain data types, so for example having a `null` value in the data throws an error. 

To avoid this problem, serialize/deserialize NSDictionary into/out of NSData for storing