### PR TITLE
Upstream IPC: Web container => Jasonette

### DIFF
--- a/app/Jasonette/Jason.h
+++ b/app/Jasonette/Jason.h
@@ -22,7 +22,7 @@
 #import "MBProgressHud.h"
 @import MediaPlayer;
 
-@interface Jason : NSObject <UINavigationControllerDelegate, UIImagePickerControllerDelegate, UITabBarControllerDelegate, PBJVisionDelegate>
+@interface Jason : NSObject <UINavigationControllerDelegate, UIImagePickerControllerDelegate, UITabBarControllerDelegate, PBJVisionDelegate, UIWebViewDelegate>
                                                                                                                                  
 @property (strong, nonatomic) NSDictionary *parser;
 @property (strong, nonatomic) NSDictionary *data;

--- a/app/Jasonette/Jason.m
+++ b/app/Jasonette/Jason.m
@@ -1834,6 +1834,7 @@
                         VC.background = nil;
                     }
                     VC.background = [[UIWebView alloc] initWithFrame: [UIScreen mainScreen].bounds];
+                    ((UIWebView*)VC.background).delegate = self;
                     
                     // Need to make the background transparent so that it doesn't flash white when first loading
                     VC.background.opaque = NO;
@@ -1841,7 +1842,15 @@
                 }
                 if(bg[@"text"]){
                     NSString *html = bg[@"text"];
-                    [((UIWebView*)VC.background) loadHTMLString:html baseURL:nil];
+                    if(VC.background.payload && VC.background.payload[@"html"] && [VC.background.payload[@"html"] isEqualToString:html]) {
+                        // same html, no need to reload
+                    } else {
+                        // different html, reload
+                        [((UIWebView*)VC.background) loadHTMLString:html baseURL:nil];
+                    }
+
+                    VC.background.payload = @{@"html": html};
+
                 }
                 
                 // allow autoplay
@@ -1867,6 +1876,28 @@
         }
     });
 }
+- (void) webViewDidFinishLoad:(UIWebView *)webView
+{
+    NSString *summon = @"var JASON={call: function(e){var n=document.createElement(\"IFRAME\");n.setAttribute(\"src\",\"jason:\"+JSON.stringify(e)),document.documentElement.appendChild(n),n.parentNode.removeChild(n),n=null}};";
+    [webView stringByEvaluatingJavaScriptFromString:summon];
+}
+- (BOOL)webView:(UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType {
+    
+    if ([[[request URL] absoluteString] hasPrefix:@"jason:"]) {
+        // Extract the selector name from the URL
+        NSString *json = [[[request URL] absoluteString] substringFromIndex:6];
+        json = [json stringByRemovingPercentEncoding];
+        
+        NSData *data = [json dataUsingEncoding:NSUTF8StringEncoding];
+        NSDictionary *action = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+        [[Jason client] call: action];
+        
+        return NO;
+    }
+    
+    return YES;
+}
+
 - (void)drawBackground:(NSString *)bg{
     dispatch_async(dispatch_get_main_queue(), ^{
 

--- a/app/Jasonette/JasonHtmlComponent.m
+++ b/app/Jasonette/JasonHtmlComponent.m
@@ -74,6 +74,26 @@
         [[Jason client] call: sender.payload[@"action"]];
     }
 }
++ (void) webViewDidFinishLoad:(UIWebView *)webView
+{
+    NSString *summon = @"var JASON={call: function(e){var n=document.createElement(\"IFRAME\");n.setAttribute(\"src\",\"jason:\"+JSON.stringify(e)),document.documentElement.appendChild(n),n.parentNode.removeChild(n),n=null}};";
+    [webView stringByEvaluatingJavaScriptFromString:summon];
+}
++ (BOOL)webView:(UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType {
 
+    if ([[[request URL] absoluteString] hasPrefix:@"jason:"]) {
+        // Extract the selector name from the URL
+        NSString *json = [[[request URL] absoluteString] substringFromIndex:6];
+        json = [json stringByRemovingPercentEncoding];
+
+        NSData *data = [json dataUsingEncoding:NSUTF8StringEncoding];
+        NSDictionary *action = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+        [[Jason client] call: action];
+        
+        return NO;
+    }
+    
+    return YES;
+}
 
 @end


### PR DESCRIPTION
This PR allows a web container to reach outside of its own sandbox and call its parent Jasonette native app's JASON actions, simply by calling:

```
JASON.call(/****JASON ACTION****/)
```

from its javascript. You just need to pass the same action JSON as an argument. Here's an example:

```
{
  "type": "html",
  "text": "<html><script>var t= {name: 'cat'}; JASON.call({trigger:\"add\",options:t})</script></html>"
}
```

Another example:

```
{
  "type": "html",
  "text": "<html><script>JASON.call({type:\"$util.alert\",options:{title: 'alert', description: 'this is an alert'}})</script></html>"
}
```

<img width="290" alt="screen shot 2017-08-07 at 11 46 55 am" src="https://user-images.githubusercontent.com/16613330/29034407-308044ea-7b66-11e7-83ef-0eaccc846d84.png">


---

This is **part 1** of the full IPC architecture as it addresses only the `webcontainer ==> Jasonette` direction communication.

The **part 2**, which is the opposite direction (`Jasonette ==> web container`), is much more complicated and involves introduction of multiple APIs since it needs ways to describe how to:

1. Identify each web container component with a unique identifier
2. Keep track of all the web containers that can be messaged
3. Dispatch a Javascript function call to only the intended web container

Part 1 is already useful for many cases and it looks like Part 2 will take some time to figure out, which is why it's broken down into two parts. The part 2 will be a separate PR.