### PR TITLE
[Fixed] App crashes when headers are not string

### DIFF
--- a/app/Jasonette.xcodeproj/project.pbxproj
+++ b/app/Jasonette.xcodeproj/project.pbxproj
@@ -75,6 +75,12 @@
 		5EE85B811DA5C0090049EACE /* JasonLayer.m in Sources */ = {isa = PBXBuildFile; fileRef = 5EE85B801DA5C0080049EACE /* JasonLayer.m */; };
 		5EF904361DD10F7000C8A94E /* JasonLogAction.m in Sources */ = {isa = PBXBuildFile; fileRef = 5EF904351DD10F6E00C8A94E /* JasonLogAction.m */; };
 		9A16EE0F1E592DC4006D3F73 /* JasonOptionHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A16EE0E1E592DC4006D3F73 /* JasonOptionHelper.m */; };
+		EF44A0971F45D9E000202D04 /* JasonNotificationCenter.m in Sources */ = {isa = PBXBuildFile; fileRef = EF44A0961F45D9E000202D04 /* JasonNotificationCenter.m */; };
+		EF44A09B1F45DEDA00202D04 /* JasonNotification.m in Sources */ = {isa = PBXBuildFile; fileRef = EF44A09A1F45DEDA00202D04 /* JasonNotification.m */; };
+		EF44A09F1F45E04900202D04 /* JasonNotificationWrongHeaderFormat.m in Sources */ = {isa = PBXBuildFile; fileRef = EF44A09E1F45E04900202D04 /* JasonNotificationWrongHeaderFormat.m */; };
+		EF44A0A41F45E6BC00202D04 /* JasonNotificationWarnings.m in Sources */ = {isa = PBXBuildFile; fileRef = EF44A0A31F45E6BC00202D04 /* JasonNotificationWarnings.m */; };
+		EF44A0A91F45E98E00202D04 /* JasonHeaderValidation.m in Sources */ = {isa = PBXBuildFile; fileRef = EF44A0A81F45E98E00202D04 /* JasonHeaderValidation.m */; };
+		EF44A0AC1F45EB5900202D04 /* JasonValidations.m in Sources */ = {isa = PBXBuildFile; fileRef = EF44A0AB1F45EB5900202D04 /* JasonValidations.m */; };
 		F9283F33AA628489204A4867 /* Pods_Jasonette.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2F0FCC971E030AF932E421D4 /* Pods_Jasonette.framework */; };
 /* End PBXBuildFile section */
 
@@ -202,6 +208,18 @@
 		9A16EE0D1E592DC4006D3F73 /* JasonOptionHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JasonOptionHelper.h; sourceTree = "<group>"; };
 		9A16EE0E1E592DC4006D3F73 /* JasonOptionHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JasonOptionHelper.m; sourceTree = "<group>"; };
 		BEB1DF488FABA35A255BC8E4 /* Pods-Jasonette.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Jasonette.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Jasonette/Pods-Jasonette.debug.xcconfig"; sourceTree = "<group>"; };
+		EF44A0951F45D9E000202D04 /* JasonNotificationCenter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JasonNotificationCenter.h; sourceTree = "<group>"; };
+		EF44A0961F45D9E000202D04 /* JasonNotificationCenter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JasonNotificationCenter.m; sourceTree = "<group>"; };
+		EF44A0991F45DEDA00202D04 /* JasonNotification.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JasonNotification.h; sourceTree = "<group>"; };
+		EF44A09A1F45DEDA00202D04 /* JasonNotification.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JasonNotification.m; sourceTree = "<group>"; };
+		EF44A09D1F45E04900202D04 /* JasonNotificationWrongHeaderFormat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JasonNotificationWrongHeaderFormat.h; sourceTree = "<group>"; };
+		EF44A09E1F45E04900202D04 /* JasonNotificationWrongHeaderFormat.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JasonNotificationWrongHeaderFormat.m; sourceTree = "<group>"; };
+		EF44A0A21F45E6BC00202D04 /* JasonNotificationWarnings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JasonNotificationWarnings.h; sourceTree = "<group>"; };
+		EF44A0A31F45E6BC00202D04 /* JasonNotificationWarnings.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JasonNotificationWarnings.m; sourceTree = "<group>"; };
+		EF44A0A71F45E98E00202D04 /* JasonHeaderValidation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JasonHeaderValidation.h; sourceTree = "<group>"; };
+		EF44A0A81F45E98E00202D04 /* JasonHeaderValidation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JasonHeaderValidation.m; sourceTree = "<group>"; };
+		EF44A0AA1F45EB5900202D04 /* JasonValidations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JasonValidations.h; sourceTree = "<group>"; };
+		EF44A0AB1F45EB5900202D04 /* JasonValidations.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JasonValidations.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -481,6 +499,8 @@
 		5E3177901D1F229200D87778 /* Helper */ = {
 			isa = PBXGroup;
 			children = (
+				EF44A0A51F45E96F00202D04 /* Validations */,
+				EF44A0941F45D9B000202D04 /* Notifications */,
 				9A16EE101E592DC9006D3F73 /* Option */,
 				5E3177041D1E411E00D87778 /* JasonHelper.h */,
 				5E3177051D1E411E00D87778 /* JasonHelper.m */,
@@ -674,6 +694,72 @@
 			name = Option;
 			sourceTree = "<group>";
 		};
+		EF44A0941F45D9B000202D04 /* Notifications */ = {
+			isa = PBXGroup;
+			children = (
+				EF44A0981F45D9E800202D04 /* NotificationCenter */,
+				EF44A09C1F45DEDE00202D04 /* Notification */,
+				EF44A0A11F45E0DB00202D04 /* Warnings */,
+			);
+			name = Notifications;
+			sourceTree = "<group>";
+		};
+		EF44A0981F45D9E800202D04 /* NotificationCenter */ = {
+			isa = PBXGroup;
+			children = (
+				EF44A0951F45D9E000202D04 /* JasonNotificationCenter.h */,
+				EF44A0961F45D9E000202D04 /* JasonNotificationCenter.m */,
+			);
+			name = NotificationCenter;
+			sourceTree = "<group>";
+		};
+		EF44A09C1F45DEDE00202D04 /* Notification */ = {
+			isa = PBXGroup;
+			children = (
+				EF44A0991F45DEDA00202D04 /* JasonNotification.h */,
+				EF44A09A1F45DEDA00202D04 /* JasonNotification.m */,
+			);
+			name = Notification;
+			sourceTree = "<group>";
+		};
+		EF44A0A01F45E04C00202D04 /* WrongHeaderFormat */ = {
+			isa = PBXGroup;
+			children = (
+				EF44A09D1F45E04900202D04 /* JasonNotificationWrongHeaderFormat.h */,
+				EF44A09E1F45E04900202D04 /* JasonNotificationWrongHeaderFormat.m */,
+			);
+			name = WrongHeaderFormat;
+			sourceTree = "<group>";
+		};
+		EF44A0A11F45E0DB00202D04 /* Warnings */ = {
+			isa = PBXGroup;
+			children = (
+				EF44A0A21F45E6BC00202D04 /* JasonNotificationWarnings.h */,
+				EF44A0A31F45E6BC00202D04 /* JasonNotificationWarnings.m */,
+				EF44A0A01F45E04C00202D04 /* WrongHeaderFormat */,
+			);
+			name = Warnings;
+			sourceTree = "<group>";
+		};
+		EF44A0A51F45E96F00202D04 /* Validations */ = {
+			isa = PBXGroup;
+			children = (
+				EF44A0AA1F45EB5900202D04 /* JasonValidations.h */,
+				EF44A0AB1F45EB5900202D04 /* JasonValidations.m */,
+				EF44A0A61F45E97700202D04 /* HeaderValidation */,
+			);
+			name = Validations;
+			sourceTree = "<group>";
+		};
+		EF44A0A61F45E97700202D04 /* HeaderValidation */ = {
+			isa = PBXGroup;
+			children = (
+				EF44A0A71F45E98E00202D04 /* JasonHeaderValidation.h */,
+				EF44A0A81F45E98E00202D04 /* JasonHeaderValidation.m */,
+			);
+			name = HeaderValidation;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -824,6 +910,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EF44A09B1F45DEDA00202D04 /* JasonNotification.m in Sources */,
 				5EE85B6A1DA444770049EACE /* JasonMapComponent.m in Sources */,
 				5E0956301DA34D70007ADC78 /* JasonImageComponent.m in Sources */,
 				5E31776D1D1E411F00D87778 /* JasonStack.m in Sources */,
@@ -833,12 +920,16 @@
 				5E3177131D1E411E00D87778 /* JasonAudioAction.m in Sources */,
 				042852531E984B890081F742 /* NoPaddingButton.m in Sources */,
 				5EE85B791DA582940049EACE /* JasonAction.m in Sources */,
+				EF44A0A91F45E98E00202D04 /* JasonHeaderValidation.m in Sources */,
 				5E2CB5C61D9DF5B600DA2B83 /* JasonComponentFactory.m in Sources */,
 				5E3177611D1E411F00D87778 /* Jason.m in Sources */,
 				5E09562D1DA33515007ADC78 /* JasonLabelComponent.m in Sources */,
+				EF44A09F1F45E04900202D04 /* JasonNotificationWrongHeaderFormat.m in Sources */,
 				5E3176611D1E400C00D87778 /* JasonAppDelegate.m in Sources */,
 				5E31776F1D1E411F00D87778 /* JasonViewController.m in Sources */,
 				5EE85B811DA5C0090049EACE /* JasonLayer.m in Sources */,
+				EF44A0AC1F45EB5900202D04 /* JasonValidations.m in Sources */,
+				EF44A0971F45D9E000202D04 /* JasonNotificationCenter.m in Sources */,
 				5E31774D1D1E411F00D87778 /* JasonMemory.m in Sources */,
 				5E09563C1DA34F1A007ADC78 /* JasonSliderComponent.m in Sources */,
 				5E3177711D1E411F00D87778 /* JasonHelper.m in Sources */,
@@ -866,6 +957,7 @@
 				5EDF644E1DB0480500C5E403 /* JasonSessionAction.m in Sources */,
 				5E31774C1D1E411F00D87778 /* JasonMediaAction.m in Sources */,
 				5E3177241D1E411F00D87778 /* JasonHorizontalSectionItem.m in Sources */,
+				EF44A0A41F45E6BC00202D04 /* JasonNotificationWarnings.m in Sources */,
 				5E3177221D1E411F00D87778 /* JasonHorizontalSection.m in Sources */,
 				04D947EB1F16ACF50063CC65 /* JASONResponseSerializer.m in Sources */,
 				5E3177301D1E411F00D87778 /* JasonGeoAction.m in Sources */,

--- a/app/Jasonette/JasonHeaderValidation.h
+++ b/app/Jasonette/JasonHeaderValidation.h
@@ -1,0 +1,16 @@
+//
+//  JasonHeaderValidation.h
+//  Jasonette
+//
+//  Created by Camilo Castro on 17-08-17.
+//  Copyright © 2017 Jasonette. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface JasonHeaderValidation : NSObject
+
+
++ (nonnull NSDictionary *) validHeaders: (nullable NSDictionary *) headers;
+
+@end

--- a/app/Jasonette/JasonHeaderValidation.m
+++ b/app/Jasonette/JasonHeaderValidation.m
@@ -1,0 +1,42 @@
+//
+//  JasonHeaderValidation.m
+//  Jasonette
+//
+//  Created by Camilo Castro on 17-08-17.
+//  Copyright © 2017 Jasonette. All rights reserved.
+//
+
+#import "JasonHeaderValidation.h"
+
+#import "JasonValidations.h"
+#import "JasonNotificationWarnings.h"
+
+@implementation JasonHeaderValidation
+
+
+
++ (nonnull NSDictionary *) validHeaders: (nullable NSDictionary *) headers
+{
+  
+  NSMutableDictionary * validHeaders = [@{} mutableCopy];
+  
+  if(headers)
+  {
+    for (NSString * key in headers)
+    {
+      id value = headers[key];
+      if(![JasonValidations isString:value])
+      {
+        [JasonNotificationWarnings
+         triggerWrongHeaderFormatWarningWithKey:key andValue:value];
+      }
+      else
+      {
+        [validHeaders setObject:value forKey:key];
+      }
+    }
+  }
+  
+  return [validHeaders copy];
+}
+@end

--- a/app/Jasonette/JasonNetworkAction.m
+++ b/app/Jasonette/JasonNetworkAction.m
@@ -7,6 +7,9 @@
 //
 #import "JasonNetworkAction.h"
 
+#import "JasonNotificationWarnings.h"
+#import "JasonValidations.h"
+
 @implementation JasonNetworkAction
 - (void)storeSession:(NSDictionary *)session forDomain:(NSString*)domain{
     UICKeyChainStore *keychain = [UICKeyChainStore keyChainStoreWithService:[domain lowercaseString]];
@@ -83,12 +86,23 @@
         
         if(headers && headers.count > 0){
             for(NSString *key in headers){
-                [manager.requestSerializer setValue:headers[key] forHTTPHeaderField:key];
+                id headerValue = headers[key];
+                if([JasonValidations isString:headerValue]){
+                    [manager.requestSerializer setValue:headerValue forHTTPHeaderField:key];
+                } else {
+                  [JasonNotificationWarnings triggerWrongHeaderFormatWarningWithKey:key andValue:headerValue];
+                }
             }
         }
+      
         if(session && session.count > 0 && session[@"header"]){
             for(NSString *key in session[@"header"]){
-                [manager.requestSerializer setValue:session[@"header"][key] forHTTPHeaderField:key];
+                id headerValue = session[@"header"][key];
+                if([JasonValidations isString:headerValue]){
+                  [manager.requestSerializer setValue:headerValue forHTTPHeaderField:key];
+                } else {
+                  [JasonNotificationWarnings triggerWrongHeaderFormatWarningWithKey:key andValue:headerValue];
+                }
             }
         }
         NSString *dataType = self.options[@"dataType"];     // dataType is deprecated. Use data_type

--- a/app/Jasonette/JasonNotification.h
+++ b/app/Jasonette/JasonNotification.h
@@ -1,0 +1,24 @@
+//
+//  JasonNotification.h
+//  Jasonette
+//
+//  Created by Camilo Castro on 17-08-17.
+//  Copyright © 2017 Jasonette. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface JasonNotification : NSObject
+
+@property (nonatomic, nonnull) NSString * name;
+
+@property (nonatomic, nonnull) NSString * message;
+
+@property (nonatomic, nullable) id data;
+
+- (instancetype _Nullable) initWithName: (nonnull NSString *) name;
+- (instancetype _Nullable) initWithName: (nonnull NSString *) name andMessage: (nonnull NSString *) message;
+- (instancetype _Nullable) initWithName: (nonnull NSString *) name message: (nonnull NSString *) message andData: (nullable id) data;
+
+- (void) trigger;
+@end

--- a/app/Jasonette/JasonNotification.m
+++ b/app/Jasonette/JasonNotification.m
@@ -1,0 +1,107 @@
+//
+//  JasonNotification.m
+//  Jasonette
+//
+//  Created by Camilo Castro on 17-08-17.
+//  Copyright © 2017 Jasonette. All rights reserved.
+//
+
+#import "JasonNotification.h"
+#import "JasonNotificationCenter.h"
+
+@implementation JasonNotification
+
+- (NSString *) name
+{
+  if(!_name)
+  {
+    _name = @"";
+  }
+  
+  return _name;
+}
+
+- (NSString *) message
+{
+  if(!_message)
+  {
+    _message = @"";
+  }
+  
+  return _message;
+}
+
+- (id) data
+{
+  if(!_data)
+  {
+    _data = nil;
+  }
+  
+  return _data;
+}
+
+- (instancetype _Nullable) initWithName: (nonnull NSString *) name
+{
+  self = [super init];
+  
+  if(self)
+  {
+      self.name = name;
+  }
+  
+  return self;
+}
+
+- (instancetype _Nullable) initWithName: (nonnull NSString *) name
+                             andMessage: (nonnull NSString *) message
+{
+  self = [super init];
+  
+  if(self)
+  {
+    self.name = name;
+    self.message = message;
+  }
+  
+  return self;
+}
+
+- (instancetype _Nullable) initWithName: (nonnull NSString *) name
+                                message: (nonnull NSString *) message
+                                andData: (nullable id) data
+{
+  self = [super init];
+  
+  if(self)
+  {
+    self.name = name;
+    self.message = message;
+    self.data = data;
+  }
+  
+  return self;
+}
+
+
+- (NSString *) description
+{
+  NSString * info = self.message;
+  
+  if(self.data)
+  {
+    info = [NSString
+            stringWithFormat:@"%@\nData: %@", self.message, self.data];
+  }
+  
+  return info;
+}
+
+- (void) trigger
+{
+  [JasonNotificationCenter
+   postNotification:self];
+}
+
+
+@end

--- a/app/Jasonette/JasonNotificationCenter.h
+++ b/app/Jasonette/JasonNotificationCenter.h
@@ -1,0 +1,23 @@
+//
+//  JasonNotificationCenter.h
+//  Jasonette
+//
+//  Created by Camilo Castro on 17-08-17.
+//  Copyright © 2017 Jasonette. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@class JasonNotification;
+
+@interface JasonNotificationCenter : NSObject
+
++ (void) postNotificationWithName: (nonnull NSString *) name;
+
++ (void) postNotificationWithName: (nonnull NSString *) name andMessage:(nonnull NSString *) message;
+
++ (void) postNotificationWithName: (nonnull NSString *) name message:(nonnull NSString *) message andData: (nullable id) data;
+
++ (void) postNotification: (nonnull JasonNotification *) notification;
+
+@end

--- a/app/Jasonette/JasonNotificationCenter.m
+++ b/app/Jasonette/JasonNotificationCenter.m
@@ -1,0 +1,57 @@
+//
+//  JasonNotificationCenter.m
+//  Jasonette
+//
+//  Created by Camilo Castro on 17-08-17.
+//  Copyright © 2017 Jasonette. All rights reserved.
+//
+
+#import "JasonNotificationCenter.h"
+#import "JasonNotification.h"
+
+@implementation JasonNotificationCenter
+
+
++ (void) postNotificationWithName: (nonnull NSString *) name
+{
+  [[NSNotificationCenter defaultCenter]
+   postNotificationName:name
+   object:self];
+}
+
++ (void) postNotificationWithName: (nonnull NSString *) name
+                       andMessage:(nonnull NSString *) message
+{
+  [[NSNotificationCenter defaultCenter]
+   postNotificationName:name
+   object:self
+   userInfo:@{@"message" : message}];
+}
+
++ (void) postNotificationWithName: (nonnull NSString *) name
+                          message:(nonnull NSString *) message
+                        andData: (nullable id) data
+{
+  if(!data)
+  {
+    data = @"Null";
+  }
+  
+  [[NSNotificationCenter defaultCenter]
+   postNotificationName:name
+   object:self
+   userInfo:@{@"message" : message, @"data" : data}];
+}
+
++ (void) postNotification: (nonnull JasonNotification *) notification
+{
+
+  [[NSNotificationCenter defaultCenter]
+   postNotificationName:notification.name
+   object:self
+   userInfo:@{@"message" : notification.message,
+              @"data" : notification.data,
+              @"notification" : notification}];
+}
+
+@end

--- a/app/Jasonette/JasonNotificationWarnings.h
+++ b/app/Jasonette/JasonNotificationWarnings.h
@@ -1,0 +1,16 @@
+//
+//  JasonNotificationWarnings.h
+//  Jasonette
+//
+//  Created by Camilo Castro on 17-08-17.
+//  Copyright © 2017 Jasonette. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "JasonNotificationWrongHeaderFormat.h"
+
+@interface JasonNotificationWarnings : NSObject
+
++ (void) triggerWrongHeaderFormatWarningWithKey: (nonnull NSString *) key andValue: (nullable id) value;
+
+@end

--- a/app/Jasonette/JasonNotificationWarnings.m
+++ b/app/Jasonette/JasonNotificationWarnings.m
@@ -1,0 +1,20 @@
+//
+//  JasonNotificationWarnings.m
+//  Jasonette
+//
+//  Created by Camilo Castro on 17-08-17.
+//  Copyright © 2017 Jasonette. All rights reserved.
+//
+
+#import "JasonNotificationWarnings.h"
+
+@implementation JasonNotificationWarnings
+
++ (void) triggerWrongHeaderFormatWarningWithKey: (nonnull NSString *) key andValue: (nullable id) value
+{
+  JasonNotificationWrongHeaderFormat * notification =
+    [[JasonNotificationWrongHeaderFormat alloc] initWithKey:key andValue:value];
+  
+  [notification trigger];
+}
+@end

--- a/app/Jasonette/JasonNotificationWrongHeaderFormat.h
+++ b/app/Jasonette/JasonNotificationWrongHeaderFormat.h
@@ -1,0 +1,22 @@
+//
+//  JasonNotificationWrongHeaderFormat.h
+//  Jasonette
+//
+//  Created by Camilo Castro on 17-08-17.
+//  Copyright © 2017 Jasonette. All rights reserved.
+//
+
+#import "JasonNotification.h"
+
+extern NSString * _Nonnull const kJasonNotificationWrongHeaderFormat;
+
+@interface JasonNotificationWrongHeaderFormat : JasonNotification
+
+@property (nonatomic, nonnull) NSString * key;
+@property (nonatomic, nonnull) id value;
+
+- (instancetype _Nullable) initWithData: (nonnull id) data;
+
+- (instancetype _Nullable) initWithKey: (nonnull NSString *) key andValue: (nullable id) value;
+
+@end

--- a/app/Jasonette/JasonNotificationWrongHeaderFormat.m
+++ b/app/Jasonette/JasonNotificationWrongHeaderFormat.m
@@ -1,0 +1,63 @@
+//
+//  JasonNotificationWrongHeaderFormat.m
+//  Jasonette
+//
+//  Created by Camilo Castro on 17-08-17.
+//  Copyright © 2017 Jasonette. All rights reserved.
+//
+
+#import "JasonNotificationWrongHeaderFormat.h"
+
+NSString * _Nonnull const kJasonNotificationWrongHeaderFormat = @"com.jasonette.notifications:warnings.wrong.header.format";
+
+@implementation JasonNotificationWrongHeaderFormat
+
+- (NSString *) key
+{
+  if (!_key) {
+    _key = @"";
+  }
+  
+  return _key;
+}
+
+- (id) value
+{
+  if(!_value)
+  {
+    _value = @"null";
+  }
+  
+  return _value;
+}
+
+- (instancetype _Nullable) initWithData: (nonnull id) data
+{
+  self = [super initWithName:kJasonNotificationWrongHeaderFormat
+                     message:@"Wrong Header Format. Header must be a String."
+                     andData:data];
+  
+  return self;
+}
+
+- (instancetype _Nullable) initWithKey: (nonnull NSString *) key
+                              andValue: (nullable id) value
+{
+  
+  self.key = key;
+  
+  if(value)
+  {
+    self = [self initWithData:@{@"key" : key, @"value" : value}];
+    self.value = value;
+  }
+  else
+  {
+    self = [self initWithData:@{@"key" : key, @"value" : @"null"}];
+    self.value = @"null";
+  }
+  
+  return self;
+}
+
+@end

--- a/app/Jasonette/JasonSessionAction.m
+++ b/app/Jasonette/JasonSessionAction.m
@@ -5,6 +5,7 @@
 //  Copyright © 2016 gliechtenstein. All rights reserved.
 //
 #import "JasonSessionAction.h"
+#import "JasonHeaderValidation.h"
 
 @implementation JasonSessionAction
 - (void)set{
@@ -25,7 +26,8 @@
         session[@"domain"] = domain;
         session[@"url"] = url;
         if(header){
-            session[@"header"] = header;
+            session[@"header"] = [JasonHeaderValidation validHeaders:header];
+          
         }
         if(body){
             session[@"body"] = body;

--- a/app/Jasonette/JasonValidations.h
+++ b/app/Jasonette/JasonValidations.h
@@ -1,0 +1,15 @@
+//
+//  JasonValidations.h
+//  Jasonette
+//
+//  Created by Camilo Castro on 17-08-17.
+//  Copyright © 2017 Jasonette. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface JasonValidations : NSObject
+
++ (BOOL) isString:(nullable id) value;
+
+@end

--- a/app/Jasonette/JasonValidations.m
+++ b/app/Jasonette/JasonValidations.m
@@ -1,0 +1,18 @@
+//
+//  JasonValidations.m
+//  Jasonette
+//
+//  Created by Camilo Castro on 17-08-17.
+//  Copyright © 2017 Jasonette. All rights reserved.
+//
+
+#import "JasonValidations.h"
+
+@implementation JasonValidations
+
++ (BOOL) isString:(nullable id) value
+{
+  return value && [value isKindOfClass:[NSString class]];
+}
+
+@end


### PR DESCRIPTION
When the headers are set in session. If they are not a string the app will crash on reload or next $network.request.

**Example Jasonette**
https://jasonbase.com/things/qd46.json

```json
{
  "$jason": {
    "head": {
      "title": "Header Test"
    },
    "body": {
      "header": {
        "title": "Header Test"
      },
      "sections": [
        {
          "items": [
            {
              "type": "button",
              "text": "Save wrong headers in session",
              "style": {
                "background": "#ff44ff",
                "padding": "20"
              },
              "action": {
                "type": "$network.request",
                "options": {
                  "method": "get",
                  "url": "https://jasonbase.com/things/G8KA.json"
                },
                "success": {
                  "type": "$session.set",
                  "options": {
                    "domain": "https://jasonbase.com/things/qd46.json",
                    "header": {
                      "X-User-Email": "{{$jason.email}}",
                      "X-User-Token": "{{$jason.token}}"
                    }
                  },
                  "success": {
                    "type": "$util.banner",
                    "options": {
                      "title": "Headers Set",
                      "description": "Headers Set in Session"
                    }
                  }
                }
              }
            }
          ]
        }
      ]
    }
  }
}
```

**Conflicting Token**
https://jasonbase.com/things/G8KA.json

```json
{
  "email": "email@example.com",
  "token": {
    "invalid": true
  }
}
```

## Why the app crashes?
Because is trying to set an NSDictionary instance when a NSString is required in

```
[manager.requestSerializer setValue:header[key] forHTTPHeaderField:key];
```
calls

## How it was solved?
1- Checks were added before setting the request headers

**JasonNetworkAction.m**

```objc
if(headers && headers.count > 0){
            for(NSString *key in headers){
                id headerValue = headers[key];
                if([JasonValidations isString:headerValue]){
                    [manager.requestSerializer setValue:headerValue forHTTPHeaderField:key];
                } else {
                  [JasonNotificationWarnings triggerWrongHeaderFormatWarningWithKey:key andValue:headerValue];
                }
            }
        }
```

2- Checks were added before setting the session headers

**JasonSessionAction.m**

```objc
if(header){
            session[@"header"] = [JasonHeaderValidation validHeaders:header];
          
        }
```

3- Added helper validation classes

**JasonHeaderValidation.m**
```objc
+ (nonnull NSDictionary *) validHeaders: (nullable NSDictionary *) headers
{
  
  NSMutableDictionary * validHeaders = [@{} mutableCopy];
  
  if(headers)
  {
    for (NSString * key in headers)
    {
      id value = headers[key];
      if(![JasonValidations isString:value])
      {
        [JasonNotificationWarnings
         triggerWrongHeaderFormatWarningWithKey:key andValue:value];
      }
      else
      {
        [validHeaders setObject:value forKey:key];
      }
    }
  }
  
  return [validHeaders copy];
}
```

4- Added Notification Helpers that can be used later in implementing debug mode feature

**JasonNotificationCenter.m**
**JasonNotification.m**

Example Listener

```objc
[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(notificationDebug:) name:kJasonNotificationWrongHeaderFormat object:nil];

- (void) notificationDebug:(NSNotification *) notification
{
  JasonNotificationWrongHeaderFormat * info = notification.userInfo[@"notification"];
  
  NSLog(@"Received Notification\n%@ %@ %@", info.message, info.key, info.value);
}
```