### PR TITLE
$network.request logging

### DIFF
--- a/app/Jasonette/JasonNetworkAction.m
+++ b/app/Jasonette/JasonNetworkAction.m
@@ -153,15 +153,18 @@
             [manager.requestSerializer setCachePolicy:NSURLRequestReloadIgnoringLocalCacheData];
         }
         
-        [self log:@{
-            @"type": @"request",
-            @"options": @{
-                @"method": method,
-                @"url": url,
-                @"header": manager.requestSerializer.HTTPRequestHeaders,
-                @"body": (parameters ? parameters : @{})
-            }
-        }];
+        
+        if(self.options[@"debug"]) {
+            [self log:@{
+                @"type": @"request",
+                @"options": @{
+                    @"method": method,
+                    @"url": url,
+                    @"header": manager.requestSerializer.HTTPRequestHeaders,
+                    @"body": (parameters ? parameters : @{})
+                }
+            }];
+        }
         
         if(method){
             if([[method lowercaseString] isEqualToString:@"post"]){
@@ -171,13 +174,14 @@
                     [manager POST:url parameters:parameters progress:^(NSProgress * _Nonnull uploadProgress) {
                         // Nothing
                     } success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject) {
-                        [self log:@{
-                            @"type": @"response",
-                            @"options": @{
-                                @"method": method, @"url": url, @"dataType": (dataType ? dataType : @"json"), @"responseObject": responseObject
-                            }
-                        }];
-
+                        if(self.options[@"debug"]) {
+                            [self log:@{
+                                @"type": @"response",
+                                @"options": @{
+                                    @"method": method, @"url": url, @"dataType": (dataType ? dataType : @"json"), @"responseObject": responseObject
+                                }
+                            }];
+                        }
                         // Ignore if the url is different
                         if(![JasonHelper isURL:task.originalRequest.URL equivalentTo:url]) return;
                         dispatch_async(dispatch_get_main_queue(), ^{
@@ -203,13 +207,14 @@
                 dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(void){
                     [manager.operationQueue cancelAllOperations];
                     [manager PUT:url parameters:parameters success:^(NSURLSessionDataTask * _Nonnull task, id  _Nonnull responseObject) {
-                        [self log:@{
-                            @"type": @"response",
-                            @"options": @{
-                                @"method": method, @"url": url, @"dataType": (dataType ? dataType : @"json"), @"responseObject": responseObject
-                            }
-                        }];
-
+                        if(self.options[@"debug"]) {
+                            [self log:@{
+                                @"type": @"response",
+                                @"options": @{
+                                    @"method": method, @"url": url, @"dataType": (dataType ? dataType : @"json"), @"responseObject": responseObject
+                                }
+                            }];
+                        }
                         // Ignore if the url is different
                         if(![JasonHelper isURL:task.originalRequest.URL equivalentTo:url]) return;
                         dispatch_async(dispatch_get_main_queue(), ^{
@@ -236,13 +241,14 @@
                 dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(void){
                     [manager.operationQueue cancelAllOperations];
                     [manager DELETE:url parameters:parameters success:^(NSURLSessionDataTask * _Nonnull task, id  _Nonnull responseObject) {
-                        [self log:@{
-                            @"type": @"response",
-                            @"options": @{
-                                @"method": method, @"url": url, @"dataType": (dataType ? dataType : @"json"), @"responseObject": responseObject
-                            }
-                        }];
-
+                        if(self.options[@"debug"]) {
+                            [self log:@{
+                                @"type": @"response",
+                                @"options": @{
+                                    @"method": method, @"url": url, @"dataType": (dataType ? dataType : @"json"), @"responseObject": responseObject
+                                }
+                            }];
+                        }
                         // Ignore if the url is different
                         if(![JasonHelper isURL:task.originalRequest.URL equivalentTo:url]) return;
                         dispatch_async(dispatch_get_main_queue(), ^{
@@ -277,13 +283,14 @@
             [manager GET:url parameters:parameters progress:^(NSProgress * _Nonnull downloadProgress) {
                 // Nothing
             } success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject) {
-                [self log:@{
-                    @"type": @"response",
-                    @"options": @{
-                        @"method": method, @"url": url, @"dataType": (dataType ? dataType : @"json"), @"responseObject": responseObject
-                    }
-                }];
-
+                if(self.options[@"debug"]) {
+                    [self log:@{
+                        @"type": @"response",
+                        @"options": @{
+                            @"method": method, @"url": url, @"dataType": (dataType ? dataType : @"json"), @"responseObject": responseObject
+                        }
+                    }];
+                }
                 // Ignore if the url is different
                 if(![JasonHelper isURL:task.originalRequest.URL equivalentTo:url]) return;
                 dispatch_async(dispatch_get_main_queue(), ^{

--- a/app/Jasonette/JasonNetworkAction.m
+++ b/app/Jasonette/JasonNetworkAction.m
@@ -142,6 +142,7 @@
         }
         
         NSString *method = self.options[@"method"];
+        if(!method) method = @"get";
         if(dataType && ([dataType isEqualToString:@"html"] || [dataType isEqualToString:@"xml"] || [dataType isEqualToString:@"rss"])){
             [self loadCookies];
         }


### PR DESCRIPTION
Code derived from @jashot7's code at https://github.com/Jasonette/documentation/issues/78#issue-250148366

The debugging feature kicks in when `options.debug` is set to true. For example:

```
{
  "type": "$network.request",
  "options": {
    "url": "...",
    "debug": "true"
  },
  "success": {
    "type": "$render"
  }
}
```