### PR TITLE
Disable the loading indicator for $require

### DIFF
--- a/app/Jasonette/Jason.m
+++ b/app/Jasonette/Jason.m
@@ -1013,9 +1013,6 @@
 }
 
 - (void)require{
-    if(VC.loading){
-        [self networkLoading:YES with:nil];
-    }
     
     NSString *origin_url = VC.url;
     


### PR DESCRIPTION
Now that we have loading.json for view transitions, it is unnecessary to have the loading indicator enabled by default for the $require action.