### PR TITLE
Textfield/area should autoscroll into viewport when focused

### DIFF
--- a/app/Jasonette/JasonViewController.m
+++ b/app/Jasonette/JasonViewController.m
@@ -206,7 +206,7 @@
 }
 - (void)keyboardDidShow:(NSNotification *)notification {
     NSDictionary* info = [notification userInfo];
-    CGSize kbSize = [[info objectForKey:UIKeyboardFrameBeginUserInfoKey] CGRectValue].size;
+    CGSize kbSize = [[info objectForKey:UIKeyboardFrameEndUserInfoKey] CGRectValue].size;
     
     if(need_to_adjust_frame){
         // Only for 'textarea' type
@@ -218,6 +218,7 @@
             CGRect aRect = self.view.frame;
             aRect.size.height -= kbSize.height;
             CGRect currently_focused_frame = [currently_focused convertRect:currently_focused.bounds toView:self.tableView];
+            currently_focused_frame.origin.y += 20; // shift offset by 20pts vertically to give some room at the bottom after scroll
             if(!CGRectContainsRect(aRect, currently_focused_frame)){
                 dispatch_async(dispatch_get_main_queue(), ^{
                     [self.tableView scrollRectToVisible:currently_focused_frame animated:YES];


### PR DESCRIPTION
Fixes 2 things:

1. iOS 11 bug with keyboard height returning 0: https://stackoverflow.com/questions/45689664/ios-11-keyboard-height-is-returning-0-in-keyboard-notification
2. Added 20pt padding at the bottom when scrolling so it looks more polished