### PR TITLE
Tabbar should stay until determined

### DIFF
--- a/app/Jasonette.xcodeproj/project.pbxproj
+++ b/app/Jasonette.xcodeproj/project.pbxproj
@@ -750,6 +750,7 @@
 				TargetAttributes = {
 					5E3176581D1E400C00D87778 = {
 						CreatedOnToolsVersion = 7.3;
+						DevelopmentTeam = ECW8LMMJGA;
 						SystemCapabilities = {
 							com.apple.BackgroundModes = {
 								enabled = 1;
@@ -1017,7 +1018,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = ECW8LMMJGA;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
@@ -1037,7 +1038,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = ECW8LMMJGA;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",

--- a/app/Jasonette.xcodeproj/project.pbxproj
+++ b/app/Jasonette.xcodeproj/project.pbxproj
@@ -750,7 +750,6 @@
 				TargetAttributes = {
 					5E3176581D1E400C00D87778 = {
 						CreatedOnToolsVersion = 7.3;
-						DevelopmentTeam = ECW8LMMJGA;
 						SystemCapabilities = {
 							com.apple.BackgroundModes = {
 								enabled = 1;
@@ -1018,7 +1017,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = ECW8LMMJGA;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
@@ -1038,7 +1037,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = ECW8LMMJGA;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",

--- a/app/Jasonette/Jason.m
+++ b/app/Jasonette/Jason.m
@@ -2545,7 +2545,11 @@
 - (void)setupTabBar: (NSDictionary *)t{
     
     if(!t && !VC.isFinal) {
-        tabController.tabBar.hidden = YES;
+        if(previous_footer && previous_footer[@"tabs"]) {
+            tabController.tabBar.hidden = NO;
+        } else {
+            tabController.tabBar.hidden = YES;
+        }
         return;
     }
     if(previous_footer && previous_footer[@"tabs"]){


### PR DESCRIPTION
Currently, the tab bar hides everytime a new tab is selected until the new tab is fully loaded.

This needs to be fixed so that the tab bars always stick around until the next view finishes loading and we can determine whether the next view contains a tab bar or not (if it doesn't, that's when we hide the tab bar)