### PR TITLE
No exception handling for tabbars when modal

### DIFF
--- a/app/Jasonette/Jason.m
+++ b/app/Jasonette/Jason.m
@@ -2543,14 +2543,20 @@
 
 # pragma mark - View rendering (tab)
 - (void)setupTabBar: (NSDictionary *)t{
-    
-    if(!t && !VC.isFinal) {
-        if(previous_footer && previous_footer[@"tabs"]) {
-            // don't touch yet until the view finalizes
-        } else {
-            tabController.tabBar.hidden = YES;
+    if(VC.isModal) {
+        // If the current view is modal, it's an entirely new view
+        // so don't need to worry about how tabs should show up.
+        // just skip the exception handling routine below.
+    } else {
+        // handling normal transition (including replace)
+        if(!t && !VC.isFinal) {
+            if(previous_footer && previous_footer[@"tabs"]) {
+                // don't touch yet until the view finalizes
+            } else {
+                tabController.tabBar.hidden = YES;
+            }
+            return;
         }
-        return;
     }
     if(previous_footer && previous_footer[@"tabs"]){
         // if previous footer tab was not null, we diff the tabs to determine whether to re-render


### PR DESCRIPTION
This fixes a tab bar bug where:

1. Launching a view without a tabbar from a view with a tabbar would result in an empty tabbar at the bottom
2. When coming back from the previous situation, the original view's tabbars are gone

This was caused by some of the edge case exception handling logic which was intended to make sure the transition is smooth. This makes things like tabbar to full screen push transition, tab1 to tab2 transition, etc. smoother, but introduced complexity when dealing with modals.

But modals are always drawn on a clean slate canvas (we don't have to worry about complex handling such as switching from tab 1 to tab 2 within the same screen) therefore we can skip the edge case exception handling altogether.

That's what I did here. It immediately fixes the issues brought up here https://github.com/Jasonette/JASONETTE-iOS/issues/283 but I expect this to fix many other weird issues that existed when transitioning modally between a view with a tabbar and one without .