### PR TITLE
support $href success callback triggered by $ok

### DIFF
--- a/app/Jasonette/JasonViewController.m
+++ b/app/Jasonette/JasonViewController.m
@@ -1020,7 +1020,7 @@
 }
 - (void)finishRefreshing{
     dispatch_async(dispatch_get_main_queue(), ^{
-        [refreshControl endRefreshing];
+        [refreshControl performSelector:@selector(endRefreshing) withObject:nil afterDelay:0.0];
     });
 }
 - (void)refresh {


### PR DESCRIPTION
## How it used to work

The `$href` action was one way street. You open a new view using the $href action but once you do so, there was no way to get a response back from the next view

```
{
  "type": "$href",
  "options": {
    "url": "..."
  }
}
```

## How it works now

Now the `$href` action supports `success` callback. 

```
{
  "type": "$href",
  "options": {
    "url": "..."
  },
  "success": {
    "type": "$util.alert",
    "options": {
      "title": "Return Value is",
      "description": "{{$jason.name}}"
    }
}
```

In order to return a value from an `$href` transition, you close the view using the `$ok` action.

The `$ok` is similar to `$back` in that it goes one step back regardless of whether it was opened modally or as a push transition (in case of iOS).

However the `$ok` can return a value to the parent view using its `options`. In order to make the previous example to work, the second view should return its control back to the first view using the following code:

```
{
  "type": "$ok",
  "options": {
    "name": "Alexa"
  }
}
```