### PR TITLE
$agent.index + url proxy & refresh fix

### DIFF
--- a/app/Jasonette/Jason.h
+++ b/app/Jasonette/Jason.h
@@ -78,7 +78,7 @@
 
 - (void)loadViewByFile: (NSString *)url asFinal: (BOOL)final;
 - (void) loadViewByFile: (NSString *)url asFinal:(BOOL)final onVC:(UIViewController<RussianDollView>*) vc;
-
+- (id)filloutTemplate: (id)template withData:(id)data;
 - (NSDictionary *)variables;
 @end
 

--- a/app/Jasonette/JasonAgentAction.m
+++ b/app/Jasonette/JasonAgentAction.m
@@ -53,26 +53,45 @@ var whoareyou = function(firstname, lastname) {
     }
 }
 
-*************************************/
-
+ *************************************/
 - (void) request {
     JasonAgentService *service = [Jason client].services[@"JasonAgentService"];
     [service request: self.options];
 }
+
+ /*************************************
+ 
+ $agent.inject: Inject JavaScript into $agent context
+ 
+    {
+        "type": "$agent.inject",
+        "options": {
+            "id": "app",
+            "items": [{
+                "url": "file://authentication.js"
+            }]
+        },
+        "success": {
+            "type": "$agent.request",
+            "options": {
+                "id": "app",
+                "method": "login",
+                "params": ["eth", "12341234"]
+            }
+        }
+    }
+  
+*************************************/
+- (void) inject {
+    JasonAgentService *service = [Jason client].services[@"JasonAgentService"];
+    [service inject: self.options];
+}
 - (void) clear {
     JasonAgentService *service = [Jason client].services[@"JasonAgentService"];
-    if (self.options && self.options[@"id"]) {
-        [service clear:self.options[@"id"] forVC:[[Jason client] getVC]];
-    } else {
-        [[Jason client] error: @{@"message": @"Please specify an ID of the agent to clear"}];
-    }
+    [service clear: self.options];
 }
 - (void) refresh {
     JasonAgentService *service = [Jason client].services[@"JasonAgentService"];
-    if (self.options && self.options[@"id"]) {
-        [service refresh:self.options[@"id"] forVC:[[Jason client] getVC]];
-    } else {
-        [[Jason client] error: @{@"message": @"Please specify an ID of the agent to refresh"}];
-    }
+    [service refresh: self.options];
 }
 @end

--- a/app/Jasonette/JasonAgentService.h
+++ b/app/Jasonette/JasonAgentService.h
@@ -13,7 +13,9 @@
 
 @interface JasonAgentService : NSObject <WKNavigationDelegate, WKScriptMessageHandler>
 - (void) request:(NSDictionary *)options;
+- (void) inject: (NSDictionary *) options;
 - (WKWebView *) setup:(NSDictionary *)options withId:(NSString *)identifier;
-- (void) refresh: (NSString *) identifier forVC: (JasonViewController *)vc;
-- (void) clear: (NSString *) identifier forVC: (JasonViewController *)vc;
+- (void) refresh: (NSDictionary *) options;
+- (void) clear: (NSDictionary *)options;
+- (void) clear: (NSString *) identifier forVC: (JasonViewController *) vc;
 @end

--- a/app/Jasonette/JasonAgentService.m
+++ b/app/Jasonette/JasonAgentService.m
@@ -116,6 +116,24 @@
     NSDictionary *action = webView.payload[@"action"];
     if(navigationAction.sourceFrame) {
         if(action) {
+            
+            // Trigger processing
+            if (action[@"trigger"]) {
+                JasonViewController *vc = (JasonViewController *)[[Jason client] getVC];
+                id event = vc.events[action[@"trigger"]];
+                NSDictionary *resolved;
+                NSMutableDictionary *data_stub = [[Jason client] variables];
+                data_stub[@"$jason"] = @{ @"url": navigationAction.request.URL.absoluteString };
+                
+                if ([event isKindOfClass:[NSArray class]]) {
+                    // if it's a trigger, must figure out whether it resolves to type: "$default"
+                    resolved = [[Jason client] filloutTemplate: event withData: data_stub];
+                } else {
+                    resolved = event;
+                }
+                action = [[Jason client] filloutTemplate: resolved withData: data_stub];
+            }
+            
             if(action[@"type"] && [action[@"type"] isEqualToString:@"$default"]) {
                 // just regular navigate like a browser
                 decisionHandler(WKNavigationActionPolicyAllow);
@@ -126,14 +144,16 @@
                     if (![webView.payload[@"state"] isEqualToString:@"rendered"]) {
                         decisionHandler(WKNavigationActionPolicyAllow);
                     } else {
-                        decisionHandler(WKNavigationActionPolicyCancel);
-                        NSMutableDictionary *event = [[NSMutableDictionary alloc] init];
-                        NSString *identifier = webView.payload[@"identifier"];
-                        if(action[@"trigger"]) {
-                            event[@"$id"] = identifier;
-                            event[@"trigger"] = action[@"trigger"];
-                            event[@"options"] = @{ @"url": navigationAction.request.URL.absoluteString };
-                            [[Jason client] call: event];
+                        if (navigationAction.navigationType == WKNavigationTypeLinkActivated) {
+                            decisionHandler(WKNavigationActionPolicyCancel);
+                            NSMutableDictionary *event = [action mutableCopy];
+                            NSString *identifier = webView.payload[@"identifier"];
+                            if(action[@"trigger"] || action[@"type"]) {
+                                event[@"$id"] = identifier;
+                                [[Jason client] call: event];
+                            }
+                        } else {
+                            decisionHandler(WKNavigationActionPolicyAllow);
                         }
                     }
                 } else {
@@ -165,22 +185,89 @@
     }]
 **********************************************/
 
-- (void) refresh: (NSString *) identifier forVC: (JasonViewController *)vc{
-    if(vc.agents && vc.agents[identifier]) {
-        WKWebView *agent = vc.agents[identifier];
-        [agent reload];
-        [[Jason client] success];
+- (void) refresh: (WKWebView *)agent withOptions: (NSDictionary *)options {
+    NSString *text = options[@"text"];
+    NSString *url = options[@"url"];
+    NSDictionary *action = options[@"action"];
+
+    BOOL isempty = NO;
+    
+    // 2. Fill in the container with HTML or JS
+    // Only when the agent is empty.
+    // If it's not empty, it means it's already been loaded. => Multiple render of the same agent shouldn't reload the entire page
+    if([agent.payload[@"state"] isEqualToString:@"empty"]) {
+        if(url) {
+            // contains "url" attribute
+            if([url containsString:@"file://"]) {
+                // File URL
+                NSString *resourcePath = [[NSBundle mainBundle] resourcePath];
+                NSString *loc = @"file:/";
+                NSString *path = [url stringByReplacingOccurrencesOfString:loc withString:resourcePath];
+                NSURL *u = [NSURL fileURLWithPath:path isDirectory:NO];
+                [agent loadFileURL:u allowingReadAccessToURL:u];
+            } else {
+                // Remote URL
+                NSURL *nsurl=[NSURL URLWithString:url];
+                NSURLRequest *nsrequest=[NSURLRequest requestWithURL:nsurl];
+                [agent loadRequest:nsrequest];
+            }
+        } else if(text) {
+            // contains "text" attribute
+            [agent loadHTMLString:text baseURL:nil];
+        } else {
+            // neither "url" nor "text" => Just empty agent
+            isempty = YES;
+        }
+    }
+    if(isempty) {
+        agent.payload[@"state"] = @"empty";
     } else {
-        [[Jason client] error: @{@"message": @"An agent with the ID doesn't exist"}];
+        agent.payload[@"state"] = @"loaded";
+    }
+    if(action) {
+        agent.userInteractionEnabled = YES;
+    } else {
+        agent.userInteractionEnabled = NO;
+    }
+    
+}
+- (void) refresh: (NSDictionary *) options {
+    if (options[@"id"]) {
+        JasonViewController *vc = (JasonViewController *)[[Jason client] getVC];
+        NSString *identifier = options[@"id"];
+        // 1. Initialize
+        if(vc.agents && vc.agents[identifier]) {
+            // Already existing agent, juse reuse the old one
+            WKWebView *agent = vc.agents[identifier];
+            agent.payload[@"state"] = @"empty";
+            NSMutableDictionary *new_options = [options mutableCopy];
+            new_options[@"text"] = agent.payload[@"text"];
+            new_options[@"url"] = agent.payload[@"url"];
+            new_options[@"action"] = agent.payload[@"action"];
+            [self refresh:agent withOptions:new_options];
+            [[Jason client] success];
+        } else {
+            [[Jason client] error: @{@"message": @"An agent with the ID doesn't exist"}];
+        }
+    } else {
+        [[Jason client] error: @{@"message": @"Please support an ID to refresh"}];
     }
 }
-- (void) clear: (NSString *) identifier forVC: (JasonViewController *)vc{
+- (void) clear: (NSString *) identifier forVC: (JasonViewController *) vc{
     if(vc.agents && vc.agents[identifier]) {
         WKWebView *agent = vc.agents[identifier];
         [agent loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"about:blank"]]];
         [[Jason client] success];
     } else {
         [[Jason client] error: @{@"message": @"An agent with the ID doesn't exist"}];
+    }
+}
+- (void) clear: (NSDictionary *)options {
+    if (options[@"id"]) {
+        JasonViewController *vc = (JasonViewController *)[[Jason client] getVC];
+        [self clear: options[@"id"] forVC: vc];
+    } else {
+        [[Jason client] error: @{@"message": @"Please support an ID to clear"}];
     }
 }
 
@@ -230,50 +317,86 @@
         agent.payload[@"action"] = action;
     }
     
-    BOOL isempty = NO;
+    agent.payload[@"url"] = url;
+    agent.payload[@"text"] = text;
     
+    [self refresh:agent withOptions:options];
     
-    // 2. Fill in the container with HTML or JS
-    // Only when the agent is empty.
-    // If it's not empty, it means it's already been loaded. => Multiple render of the same agent shouldn't reload the entire page
-    if([agent.payload[@"state"] isEqualToString:@"empty"]) {
-        if(url) {
-            // contains "url" attribute
-            if([url containsString:@"file://"]) {
-                // File URL
-                NSString *resourcePath = [[NSBundle mainBundle] resourcePath];
-                NSString *loc = @"file:/";
-                NSString *path = [url stringByReplacingOccurrencesOfString:loc withString:resourcePath];
-                NSURL *u = [NSURL fileURLWithPath:path isDirectory:NO];
-                [agent loadFileURL:u allowingReadAccessToURL:u];
-            } else {
-                // Remote URL
-                NSURL *nsurl=[NSURL URLWithString:url];
-                NSURLRequest *nsrequest=[NSURLRequest requestWithURL:nsurl];
-                [agent loadRequest:nsrequest];
-            }
-        } else if(text) {
-            // contains "text" attribute
-            [agent loadHTMLString:text baseURL:nil];
-        } else {
-            // neither "url" nor "text" => Just empty agent
-            isempty = YES;
-        }
-    }
-    if(isempty) {
-        agent.payload[@"state"] = @"empty";
-    } else {
-        agent.payload[@"state"] = @"loaded";
-    }
-    if(action) {
-        agent.userInteractionEnabled = YES;
-    } else {
-        agent.userInteractionEnabled = NO;
-    }
     vc.agents[identifier] = agent;
+
     return agent;
 }
 
+- (void) inject: (NSDictionary *) options {
+    NSString *identifier = options[@"id"];
+    JasonViewController *vc = (JasonViewController *)[[Jason client] getVC];
+    WKWebView *agent = vc.agents[identifier];
+    if (agent) {
+        NSArray *items = options[@"items"];
+        dispatch_group_t requireGroup = dispatch_group_create();
+        NSMutableArray *codes = [[NSMutableArray alloc] init];
+        NSMutableArray *errors = [[NSMutableArray alloc] init];
+        if (items && items.count > 0) {
+            for(int i=0; i<items.count; i++) {
+                dispatch_group_enter(requireGroup);
+                NSDictionary *item = items[i];
+                NSString *inject_text = item[@"text"];
+                NSString *inject_type = item[@"type"];
+                NSString *inject_url = item[@"url"];
+                [codes addObject:@""];
+                if (inject_url) {
+                    if ([inject_url hasPrefix:@"file://"]) {
+                        NSString *code = [JasonHelper read_local_file:inject_url];
+                        if (code) {
+                            codes[i] = code;
+                        } else {
+                            [errors addObject: @"the file doesn't exist"];
+                        }
+                        dispatch_group_leave(requireGroup);
+                    } else if([inject_url hasPrefix:@"http"]) {
+                        AFHTTPSessionManager *manager = [AFHTTPSessionManager manager];
+                        manager.responseSerializer = [AFHTTPResponseSerializer serializer];
+                        manager.responseSerializer.acceptableContentTypes = [NSSet setWithObjects:@"text/javascript", @"text/plain", @"application/javascript", nil];
+                        [manager GET:inject_url parameters:nil progress:^(NSProgress * _Nonnull downloadProgress) {
+                            // Nothing
+                        } success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject) {
+                            NSString *code = [JasonHelper UTF8StringFromData:((NSData *)responseObject)];
+                            codes[i] = code;
+                            dispatch_group_leave(requireGroup);
+                        } failure:^(NSURLSessionDataTask * _Nullable task, NSError * _Nonnull error) {
+                            [errors addObject: @"Failed to fetch script"];
+                            dispatch_group_leave(requireGroup);
+                        }];
+                    } else {
+                        [errors addObject: @"the injection must load from a file:// or http[s]:// url"];
+                        dispatch_group_leave(requireGroup);
+                    }
+                } else if (inject_text) {
+                    codes[i] = inject_text;
+                    dispatch_group_leave(requireGroup);
+                } else {
+                    [errors addObject: @"must specify either a url or text"];
+                    dispatch_group_leave(requireGroup);
+                }
+            }
+            dispatch_group_notify(requireGroup, dispatch_get_main_queue(), ^{
+                if (errors.count > 0) {
+                    [[Jason client] error: @{@"message": [errors componentsJoinedByString:@"; "]}];
+                } else {
+                    NSString *code_string = [codes componentsJoinedByString:@"\n"];
+                    [self inject: code_string into: agent];
+                }
+            });
+        }
+    }
+}
+
+- (void) inject: (NSString *) code into: (WKWebView*) agent{
+    [agent evaluateJavaScript:code completionHandler:^(id _Nullable res, NSError * _Nullable error) {
+        // Step 2. Execute the method with params
+        [[Jason client] success];
+    }];
+}
 
 - (void) request: (NSDictionary *) options {
     NSString *method = options[@"method"];


### PR DESCRIPTION
1. Must handle cases where the agent's action is a trigger => Need to find the corresponding event, parse it, and then figure out if it's "type": "$default". Let the traffic through ONLY if it's "type": "$default"
2. Fix refresh so that it actually reloads from scratch
3. $agent.inject: Inject JS into agent.