### PR TITLE
Stringify

### DIFF
--- a/app/Jasonette/Jason.m
+++ b/app/Jasonette/Jason.m
@@ -2378,9 +2378,10 @@
         }
     } else {
         if(left_menu[@"text"]){
+            NSString *left_menu_text = [left_menu[@"text"] description];
             UIButton *button = [[UIButton alloc] init];
-            [button setTitle:left_menu[@"text"] forState:UIControlStateNormal];
-            [button setTitle:left_menu[@"text"] forState:UIControlStateFocused];
+            [button setTitle:left_menu_text forState:UIControlStateNormal];
+            [button setTitle:left_menu_text forState:UIControlStateFocused];
             NSDictionary *style = left_menu[@"style"];
             if(style && style[@"color"]){
                 UIColor *c = [JasonHelper colorwithHexString:style[@"color"] alpha:1.0];
@@ -2440,9 +2441,10 @@
         rightBarButton = nil;
     } else {
         if(right_menu[@"text"]){
+            NSString *right_menu_text = [right_menu[@"text"] description];
             UIButton *button = [[UIButton alloc] init];
-            [button setTitle:right_menu[@"text"] forState:UIControlStateNormal];
-            [button setTitle:right_menu[@"text"] forState:UIControlStateFocused];
+            [button setTitle:right_menu_text forState:UIControlStateNormal];
+            [button setTitle:right_menu_text forState:UIControlStateFocused];
             NSDictionary *style = right_menu[@"style"];
             if(style && style[@"color"]){
                 UIColor *c = [JasonHelper colorwithHexString:style[@"color"] alpha:1.0];
@@ -2700,7 +2702,7 @@
             }
         }
         if(badge[@"text"]){
-            barButton.badgeValue = badge[@"text"];
+            barButton.badgeValue = [badge[@"text"] description];
         } else {
             barButton.badgeValue = @" ";
         }

--- a/app/Jasonette/Jason.m
+++ b/app/Jasonette/Jason.m
@@ -2540,7 +2540,7 @@
                     } else if([titleDict[@"type"] isEqualToString:@"label"]) {
                         
                         UILabel *tLabel = [[UILabel alloc] init];
-                        tLabel.text = titleDict[@"text"];
+                        tLabel.text = [titleDict[@"text"] description];
                         NSString *font = @"HelveticaNeue";
                         CGFloat size = 20;
                         CGFloat x=0;
@@ -2588,12 +2588,9 @@
                         }
                     }
                 }
-            } else if([nav[@"title"] isKindOfClass:[NSString class]]){
-                // Basic title (simple text)
-                v.navigationItem.titleView = nil;
-                v.navigationItem.title = nav[@"title"];
             } else {
                 v.navigationItem.titleView = nil;
+                v.navigationItem.title = [nav[@"title"] description];
             }
             
         } else {

--- a/app/Jasonette/Jason.m
+++ b/app/Jasonette/Jason.m
@@ -2948,17 +2948,15 @@
 }
 - (void)setTabBarItem:(UITabBarItem *)item withTab: (NSDictionary *)tab{
     NSString *image = tab[@"image"];
-    NSString *text = tab[@"text"];
-    NSString *badge = tab[@"badge"];
     
     SDWebImageManager *manager = [SDWebImageManager sharedManager];
-    if(text){
-        [item setTitle:text];
+    if(tab[@"text"]){
+        [item setTitle:[tab[@"text"] description]];
     } else {
         [item setTitle:@""];
     }
     if(image){
-        if(text){
+        if(tab[@"text"]){
             [item setImageInsets:UIEdgeInsetsMake(0, 0, 0, 0)];
             [item setTitlePositionAdjustment:UIOffsetMake(0.0, -2.0)];
         } else {
@@ -2984,8 +2982,8 @@
     } else {
         [item setTitlePositionAdjustment:UIOffsetMake(0.0, -18.0)];
     }
-    if(badge){
-        [item setBadgeValue:badge];
+    if(tab[@"badge"]){
+        [item setBadgeValue:[tab[@"badge"] description]];
     }
 }
 

--- a/app/Jasonette/JasonButtonComponent.m
+++ b/app/Jasonette/JasonButtonComponent.m
@@ -154,7 +154,7 @@
     else{
         [component setImage:nil forState:UIControlStateNormal];
         if(json[@"text"]){
-            [component setTitle:json[@"text"] forState:UIControlStateNormal];
+            [component setTitle:[json[@"text"] description] forState:UIControlStateNormal];
         }
 
     }

--- a/app/Jasonette/JasonComponent.m
+++ b/app/Jasonette/JasonComponent.m
@@ -281,7 +281,7 @@
         // Therefore we need to set the text one more time here.
         if([el isKindOfClass:[UILabel class]]){
             if(json[@"text"]){
-                [el setValue:json[@"text"] forKey:@"text"];
+                [el setValue:[json[@"text"] description] forKey:@"text"];
             }
         }
     }

--- a/app/Jasonette/JasonHelper.m
+++ b/app/Jasonette/JasonHelper.m
@@ -468,10 +468,12 @@
         return [ratio floatValue];
     }
 }
-+ (CGFloat)pixelsInDirection: (NSString *)direction fromExpression: (NSString *)expression {
++ (CGFloat)pixelsInDirection: (NSString *)direction fromExpression: (id)exp {
     NSError *error = nil;
     CGFloat full_dimension;
-    if(!expression) return 0;
+    if(!exp) return 0;
+    
+    NSString *expression = [exp description];
     
     if([direction isEqualToString:@"vertical"]){
         full_dimension = [[UIScreen mainScreen] bounds].size.height;

--- a/app/Jasonette/JasonHtmlComponent.m
+++ b/app/Jasonette/JasonHtmlComponent.m
@@ -29,7 +29,7 @@
 
     
     if(json[@"text"] && ![[NSNull null] isEqual:json[@"text"]]){
-        NSString *html = json[@"text"];
+        NSString *html = [json[@"text"] description];
         [((UIWebView*)component) loadHTMLString:html baseURL:nil];
         component.scrollView.scrollEnabled = NO;
 

--- a/app/Jasonette/JasonLabelComponent.m
+++ b/app/Jasonette/JasonLabelComponent.m
@@ -14,9 +14,7 @@
     if(json){
         component.numberOfLines = 0;
         if(json[@"text"] && ![json[@"text"] isEqual:[NSNull null]]){
-            if([json[@"text"] length] > 0){
-                component.text = json[@"text"];
-            }
+            component.text = [json[@"text"] description];
         }
     }
     

--- a/app/Jasonette/JasonLayer.m
+++ b/app/Jasonette/JasonLayer.m
@@ -111,7 +111,7 @@ static NSMutableDictionary *_stylesheet = nil;
                 
                 // Must set text after setting style
                 
-                layerChild.text = layer[@"text"];
+                layerChild.text = [layer[@"text"] description];
                 [layerChild sizeToFit];
                 
                 UIView *layerView = [[UIView alloc] init];

--- a/app/Jasonette/JasonLayout.m
+++ b/app/Jasonette/JasonLayout.m
@@ -111,20 +111,19 @@ static NSMutableDictionary *_stylesheet = nil;
                     // image button
                     options[@"indexPath"] = indexPath;
                 }
+                
+                NSString *value;
                 if (form && child[@"name"]) {
                     // get the form value first
-                    NSString *value = form[child[@"name"]];
-                    
-                    // if the value doesn't exist but the 'value' attribute exists, use that one
-                    if(!value && child[@"value"]) {
-                        value = child[@"value"];
-                    }
-                    
-                    // If after all this, the value is still nil, just use an empty string
-                    if (!value) value = @"";
-                    
-                    options[@"value"] = value;
+                    value = form[child[@"name"]];
                 }
+                // if the value doesn't exist but the 'value' attribute exists, use that one
+                if(!value && child[@"value"]) {
+                    value = child[@"value"];
+                }
+                // If after all this, the value is still nil, just use an empty string
+                if (!value) value = @"";
+                options[@"value"] = value;
                 options[@"parent"] = item[@"type"];
                 
                 UIView *el;

--- a/app/Jasonette/JasonMapComponent.m
+++ b/app/Jasonette/JasonMapComponent.m
@@ -82,8 +82,8 @@
                 if(!description){
                     description = @"";
                 }
-                [annotation setTitle:title];
-                [annotation setSubtitle:description];
+                [annotation setTitle:[title description]];
+                [annotation setSubtitle:[description description]];
             }
             [annotation setCoordinate:coord.coordinate];
             [mapView addAnnotation:annotation];

--- a/app/Jasonette/JasonSliderComponent.m
+++ b/app/Jasonette/JasonSliderComponent.m
@@ -15,10 +15,10 @@
     component.continuous = YES;
     component.value = 0.5;
     component.payload = [[NSMutableDictionary alloc] init];
-    if(json && json[@"name"]) component.payload[@"name"] = json[@"name"];
+    if(json && json[@"name"]) component.payload[@"name"] = [json[@"name"] description];
     if(json && json[@"action"]) component.payload[@"action"] = json[@"action"];
 
-    if(options && options[@"value"] && [options[@"value"] length] > 0){
+    if(options && options[@"value"]){
         component.value = [options[@"value"] floatValue];
     }
     

--- a/app/Jasonette/JasonSwitchComponent.m
+++ b/app/Jasonette/JasonSwitchComponent.m
@@ -22,7 +22,7 @@
   }
   
   component.payload = [[NSMutableDictionary alloc] init];
-  if(json && json[@"name"]) component.payload[@"name"] = json[@"name"];
+  if(json && json[@"name"]) component.payload[@"name"] = [json[@"name"] description];
   if(json && json[@"action"]) component.payload[@"action"] = json[@"action"];
 
   JasonOptionHelper * data = [[JasonOptionHelper alloc] initWithOptions:options];

--- a/app/Jasonette/JasonTextareaComponent.m
+++ b/app/Jasonette/JasonTextareaComponent.m
@@ -26,7 +26,7 @@
     
     NSMutableDictionary *payload = [[NSMutableDictionary alloc] init];
     if(mutated_json[@"name"]){
-        payload[@"name"] = mutated_json[@"name"];
+        payload[@"name"] = [mutated_json[@"name"] description];
     }
     if(mutated_json[@"action"]){
         payload[@"action"] = mutated_json[@"action"];
@@ -50,9 +50,9 @@
     }
     
     if(options && options[@"value"]){
-        component.text = options[@"value"];
+        component.text = [options[@"value"] description];
     } else if(json && json[@"value"]){
-        component.text = json[@"value"];
+        component.text = [json[@"value"] description];
     } else {
         component.text = @"";
     }
@@ -79,7 +79,7 @@
     
     if(mutated_json[@"placeholder"]){
         UIColor *placeholder_color;
-        NSString *placeholder_raw_str = mutated_json[@"placeholder"];
+        NSString *placeholder_raw_str = [mutated_json[@"placeholder"] description];
         
         // Color
         if(style[@"placeholder_color"]){

--- a/app/Jasonette/JasonTextfieldComponent.m
+++ b/app/Jasonette/JasonTextfieldComponent.m
@@ -15,7 +15,7 @@
     
     NSMutableDictionary *payload = [[NSMutableDictionary alloc] init];
     if(json[@"name"]){
-        payload[@"name"] = json[@"name"];
+        payload[@"name"] = [json[@"name"] description];
     }
     if(json[@"action"]){
         payload[@"action"] = json[@"action"];
@@ -39,9 +39,9 @@
     }
 
     if(options && options[@"value"]){
-        component.text = options[@"value"];
+        component.text = [options[@"value"] description];
     } else if(json && json[@"value"]){
-        component.text = json[@"value"];
+        component.text = [json[@"value"] description];
     } else {
         component.text = @"";
     }
@@ -79,7 +79,7 @@
     }
     if(json[@"placeholder"]){
         UIColor *placeholder_color;
-        NSString *placeholder_raw_str = json[@"placeholder"];
+        NSString *placeholder_raw_str = [json[@"placeholder"] description];
         
         // Color
         if(style[@"placeholder_color"]){

--- a/app/Jasonette/JasonUtilAction.m
+++ b/app/Jasonette/JasonUtilAction.m
@@ -8,8 +8,8 @@
 
 @implementation JasonUtilAction
 - (void)banner{
-    NSString *title = self.options[@"title"];
-    NSString *description = self.options[@"description"];
+    NSString *title = [self.options[@"title"] description];
+    NSString *description = [self.options[@"description"] description];
     NSString *type = self.options[@"type"];
     if(!title) title = @"Notice";
     if(!description) description = @"";
@@ -37,7 +37,7 @@
 
 - (void)toast{
     NSString *type = self.options[@"type"];
-    NSString *text = self.options[@"text"];
+    NSString *text = [self.options[@"text"] description];
     
     if(!type) type = @"success";
     if(!text) text = @"Updated";
@@ -64,8 +64,8 @@
 
 - (void)alert{
     [[Jason client] loading:NO];
-    NSString *title = self.options[@"title"];
-    NSString *description = self.options[@"description"];
+    NSString *title = [self.options[@"title"] description];
+    NSString *description = [self.options[@"description"] description];
     // 1. Instantiate alert
     UIAlertController *alert= [UIAlertController alertControllerWithTitle:title message:description preferredStyle:UIAlertControllerStyleAlert];
     
@@ -186,7 +186,7 @@
                     }
                 } else if([item[@"type"] isEqualToString:@"text"]){
                     if(item[@"text"]){
-                        [share_items addObject:item[@"text"]];
+                        [share_items addObject:[item[@"text"] description]];
                     }
                     counter--;
                 }
@@ -218,7 +218,7 @@
                 }
             } else if([item[@"type"] isEqualToString:@"text"]){
                 if(item[@"text"]){
-                    NSDictionary *res = [NSDictionary dictionaryWithObject:item[@"text"] forKey:(NSString *)kUTTypeUTF8PlainText];
+                    NSDictionary *res = [NSDictionary dictionaryWithObject:[item[@"text"] description] forKey:(NSString *)kUTTypeUTF8PlainText];
                     [to_copy addObject:res];
                 }
             } else if([item[@"type"] isEqualToString:@"image"]){
@@ -256,13 +256,13 @@
 
 }
 - (void)picker{
-    NSString *title = self.options[@"title"];
+    NSString *title = [self.options[@"title"] description];
     NSArray *items = self.options[@"items"];
     UIAlertController *alert = [UIAlertController alertControllerWithTitle:title message:nil preferredStyle:UIAlertControllerStyleActionSheet];
     
     for(int i = 0 ; i < items.count ; i++){
         NSDictionary *item = items[i];
-        UIAlertAction *action = [UIAlertAction actionWithTitle:item[@"text"]
+        UIAlertAction *action = [UIAlertAction actionWithTitle:[item[@"text"] description]
                                                               style:UIAlertActionStyleDefault handler:^(UIAlertAction * action) {
                                                                   if(item[@"href"]){
                                                                       [[Jason client] go:item[@"href"]];
@@ -284,10 +284,10 @@
     NSString *description = @"";
     if(self.options){
         if(self.options[@"title"]){
-            title = self.options[@"title"];
+            title = [self.options[@"title"] description];
         }
         if(self.options[@"description"]){
-            description = self.options[@"description"];
+            description = [self.options[@"description"] description];
         }
     }
 

--- a/app/Jasonette/JasonViewController.m
+++ b/app/Jasonette/JasonViewController.m
@@ -1486,7 +1486,7 @@
                                           PHFComposeBarViewInitialHeight);
                 self.composeBarView = [[PHFComposeBarView alloc] initWithFrame:frame];
                 if(field[@"name"]){
-                    self.composeBarView.textView.payload = [@{@"name": field[@"name"]} mutableCopy];
+                    self.composeBarView.textView.payload = [@{@"name": [field[@"name"] description]} mutableCopy];
                 }
                 [self.composeBarView setDelegate:self];
                 [self.view addSubview:self.composeBarView];
@@ -1538,7 +1538,7 @@
             }
             
             if(field[@"placeholder"]){
-                [self.composeBarView setPlaceholder:field[@"placeholder"]];
+                [self.composeBarView setPlaceholder:[field[@"placeholder"] description]];
             }
             
             if(chat_input[@"left"]){
@@ -1609,7 +1609,7 @@
                         }
                     }
                     
-                    [self.composeBarView setButtonTitle:chat_input[@"right"][@"text"]];
+                    [self.composeBarView setButtonTitle:[chat_input[@"right"][@"text"] description]];
                 }
             }
             


### PR DESCRIPTION
Previously there was a strict rule about keeping every attribute a string format. This has confused a lot of people when getting started because for example you would expect something like this to work right out of the box:

```
{
  "type": "label", "text": 42
}
```

But it didn't because you had to EXPLICITLY set every attribute value to string, so the `42` had to be wrapped with double quotes like this:

```
{
  "type": "label", "text": "42"
}
```

This PR fixes this problem so all types automatically get typecasted to string when printing to the view. Numbers become strings and booleans become strings too (`true` becomes `"1"` and `false` becomes `"0"`)

Here are the features that have been updated to reflect this:

# View

- header
    - basic title
    - advanced title
    - menu
        - text
        - badge
            - text
- footer
    - tabs
        - items
            - text
            - badge
    - input
        - textfield
            - name
            - placeholder
        - right
            - text
- layers
    - type:label
        - text
    
- components
    - type:label
        - text
    - type:button
        - text
    - type:textfield
        - name
        - value
        - placeholder
    - type:textarea
        - name
        - value
        - placeholder
    - type:slider
        - name
        - value
    - type:switch
        - name
        - value
    - type:map
        - pins
            - title
            - description
    - type: Html
        - text


# Action

$util actions

# Styling

all styles with number metrics (size, width, height, etc.)