### PR TITLE
added explicit version to pods

### DIFF
--- a/app/Podfile
+++ b/app/Podfile
@@ -23,9 +23,9 @@ target 'Jasonette' do
   pod "AFOAuth2Manager"
   pod "CYRTextView"
   pod 'FreeStreamer', :git => "https://github.com/muhku/FreeStreamer.git"
-  pod 'SDWebImage', :git => "https://github.com/rs/SDWebImage.git"
+  pod 'SDWebImage', :git => "https://github.com/rs/SDWebImage.git", :tag => '3.8.1'
   pod 'SZTextView'
-  pod 'SBJson'
+  pod 'SBJson', '~> 4.0.2'
   pod 'DHSmartScreenshot'
   pod 'NSHash'
   pod 'JSCoreBom', '~> 1.1.1'


### PR DESCRIPTION
Added two explicit versions to `Podfile`

```ruby
  pod 'SDWebImage', :git => "https://github.com/rs/SDWebImage.git", :tag => '3.8.1'
  pod 'SBJson', '~> 4.0.2'
```

Since Jasonette can not work with more updated versions
it's best to use explicit versions until the core change the function calls to these libs.